### PR TITLE
[FEAT] 성지순례 일부 기능 및 임시 더미데이터 추가

### DIFF
--- a/src/main/java/com/favoriteplace/InitDB.java
+++ b/src/main/java/com/favoriteplace/InitDB.java
@@ -293,7 +293,7 @@ public class InitDB {
                     .type(type)
                     .saleDeadline(null)
                     .point(0L)
-                    .description(null)
+                    .description("item 설명")
                     .category(itemCategory)
                     .build();
             em.persist(item);

--- a/src/main/java/com/favoriteplace/InitDB.java
+++ b/src/main/java/com/favoriteplace/InitDB.java
@@ -31,7 +31,6 @@ public class InitDB {
         initService.initWeatheringWithYou();
         initService.initOshiNoKo();
         initService.initJujutsuKaisen();
-//        initService.initDB();
     }
 
     @Component

--- a/src/main/java/com/favoriteplace/InitDB.java
+++ b/src/main/java/com/favoriteplace/InitDB.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class InitDB {
@@ -25,9 +27,10 @@ public class InitDB {
 
     @PostConstruct
     public void init(){
-//        initService.createMember("1");
-        initService.initRallyAndPilgrimage();
-        initService.initDB();
+        initService.initAddress();
+        initService.initWeatheringWithYou();
+        initService.initOshiNoKo();
+//        initService.initDB();
     }
 
     @Component
@@ -37,149 +40,167 @@ public class InitDB {
         private final EntityManager em;
         private final AddressRepository addressRepository;
 
-        public void initDB(){
-            Image image1 = Image.builder()
-                    .post(null).guestBook(null)
-                    .url("imgIcon").build();
-            Image image2 = Image.builder()
-                    .post(null).guestBook(null)
-                    .url("imgTitle").build();
-            em.persist(image1); em.persist(image2);
-
-            Item item1 = Item.builder()
-                    .image(image1).name("icon1")
-                    .status(SaleStatus.NOT_FOR_SALE).type(ItemType.ICON)
-                    .saleDeadline(null).point(10L).category(ItemCategory.NEW)
-                    .saleDeadline(null).description(null).build();
-            Item item2 = Item.builder()
-                    .image(image2).name("title1")
-                    .status(SaleStatus.NOT_FOR_SALE).type(ItemType.TITLE)
-                    .saleDeadline(null).point(10L).category(ItemCategory.NEW)
-                    .description(null).build();
-            em.merge(item1); em.merge(item2);
-
-            Member member = Member.builder()
-                    .id(0L).profileIcon(item1)
-                    .profileTitle(item2).email("aaa@email.com")
-                    .password("1234").birthday(null)
-                    .nickname("user1").description("hi")
-                    .profileImageUrl("").status(MemberStatus.Y)
-                    .alarmAllowance(false).point(0L)
-                    .loginType(LoginType.SELF).refreshToken("")
-                    .build();
-            em.merge(member);
-
-            Post post1 = Post.builder()
-                    .id(0L).member(member)
-                    .title("게시글1").content("abcdefg")
-                    .likeCount(10L).view(10L).build();
-            Post post2 = Post.builder()
-                    .id(1L).member(member)
-                    .title("게시글2").content("abcdefg")
-                    .likeCount(15L).view(15L).build();
-            Post post3 = Post.builder()
-                    .id(2L).member(member)
-                    .title("게시글3").content("abcdefg")
-                    .likeCount(20L).view(20L).build();
-            Post post4 = Post.builder()
-                    .id(3L).member(member)
-                    .title("게시글4").content("abcdefg")
-                    .likeCount(20L).view(20L).build();
-            Post post5 = Post.builder()
-                    .id(4L).member(member)
-                    .title("게시글5").content("abcdefg")
-                    .likeCount(25L).view(25L).build();
-            Post post6 = Post.builder()
-                    .id(5L).member(member)
-                    .title("게시글6").content("abcdefg")
-                    .likeCount(30L).view(30L).build();
-            Post post7 = Post.builder()
-                    .id(6L).member(member)
-                    .title("게시글7").content("abcdefg")
-                    .likeCount(35L).view(35L).build();
-            em.merge(post1); em.merge(post2); em.merge(post3); em.merge(post4); em.merge(post5); em.merge(post6); em.merge(post7);
-
-
-            Address address = addressRepository.findByStateAndDistrict("도쿄도", "시부야구");
-            Address address2 = Address.builder().state("도쿄도").district("시부야구").build();
-            em.persist(address2);
-
-            Rally rally1 = Rally.builder().id(0L)
-                    .item(item1).image(image1).name("최애의 아이")
-                    .description("환생한 내가 아이돌의 자녀??!!").achieveNumber(10L)
-                    .pilgrimageNumber(4L).build();
-            Rally rally2 = Rally.builder().id(1L)
-                    .item(item2).image(image2).name("날씨의 아이")
-                    .description("비야 멈춰라!").achieveNumber(20L)
-                    .pilgrimageNumber(2L).build();
-            em.merge(rally1); em.merge(rally2);
-
-            Pilgrimage pilgrimage1 = Pilgrimage.builder()
-                    .address(address2).rally(rally1).virtualImage(image1).realImage(image1)
-                    .rallyName("최애의 아이").detailAddress("스크램블 교차로1").latitude(1.1).longitude(1.1).build();
-            Pilgrimage pilgrimage2 = Pilgrimage.builder()
-                    .address(address2).rally(rally2).virtualImage(image2).realImage(image2)
-                    .rallyName("최애의 아이").detailAddress("스크램블 교차로2").latitude(1.1).longitude(1.1).build();
-            em.merge(pilgrimage1); em.merge(pilgrimage2);
-
-            GuestBook guestBook1 = GuestBook.builder().id(0L)
-                    .member(member).pilgrimage(pilgrimage1)
-                    .title("인증글1").content("인증글내용1").likeCount(5L).view(5L).latitude(1.1).longitude(1.1)
-                    .build();
-            GuestBook guestBook2 = GuestBook.builder().id(1L)
-                    .member(member).pilgrimage(pilgrimage1)
-                    .title("인증글2").content("인증글내용2").likeCount(10L).view(10L).latitude(1.1).longitude(1.1)
-                    .build();
-            GuestBook guestBook3 = GuestBook.builder()
-                    .member(member).pilgrimage(pilgrimage1)
-                    .title("인증글3").content("인증글내용3").likeCount(15L).view(15L).latitude(1.1).longitude(1.1)
-                    .build();
-            GuestBook guestBook4 = GuestBook.builder()
-                    .member(member).pilgrimage(pilgrimage2)
-                    .title("인증글4").content("인증글내용4").likeCount(20L).view(20L).latitude(1.1).longitude(1.1)
-                    .build();
-            GuestBook guestBook5 = GuestBook.builder()
-                    .member(member).pilgrimage(pilgrimage2)
-                    .title("인증글5").content("인증글내용5").likeCount(20L).view(20L).latitude(1.1).longitude(1.1)
-                    .build();
-            GuestBook guestBook6 = GuestBook.builder()
-                    .member(member).pilgrimage(pilgrimage2)
-                    .title("인증글6").content("인증글내용6").likeCount(25L).view(25L).latitude(1.1).longitude(1.1)
-                    .build();
-            GuestBook guestBook7 = GuestBook.builder()
-                    .member(member).pilgrimage(pilgrimage2)
-                    .title("인증글7").content("인증글내용7").likeCount(30L).view(30L).latitude(1.1).longitude(1.1)
-                    .build();
-            em.merge(guestBook1);em.merge(guestBook2); em.merge(guestBook3); em.merge(guestBook4); em.merge(guestBook5); em.merge(guestBook6); em.merge(guestBook7);
-
-            Comment comment1 = Comment.builder()
-                    .member(member).post(null).guestBook(guestBook1).content("G댓글1").build();
-            Comment comment2 = Comment.builder()
-                    .member(member).post(null).guestBook(guestBook1).content("G댓글2").build();
-            Comment comment3 = Comment.builder()
-                    .member(member).post(null).guestBook(guestBook1).content("G댓글3").build();
-            Comment comment4 = Comment.builder()
-                    .member(member).post(post1).guestBook(null).content("P댓글4").build();
-            Comment comment5 = Comment.builder()
-                    .member(member).post(post1).guestBook(null).content("P댓글5").build();
-            Comment comment6 = Comment.builder()
-                    .member(member).post(post1).guestBook(null).content("P댓글6").build();
-            em.merge(comment1); em.merge(comment2);em.merge(comment3);em.merge(comment4);em.merge(comment5);em.merge(comment6);
-        }
+//        public void initDB(){
+//            Image image1 = Image.builder()
+//                    .post(null).guestBook(null)
+//                    .url("imgIcon").build();
+//            Image image2 = Image.builder()
+//                    .post(null).guestBook(null)
+//                    .url("imgTitle").build();
+//            em.persist(image1); em.persist(image2);
+//
+//            Item item1 = Item.builder()
+//                    .image(image1).name("icon1")
+//                    .status(SaleStatus.NOT_FOR_SALE).type(ItemType.ICON)
+//                    .saleDeadline(null).point(10L).category(ItemCategory.NEW)
+//                    .saleDeadline(null).description(null).build();
+//            Item item2 = Item.builder()
+//                    .image(image2).name("title1")
+//                    .status(SaleStatus.NOT_FOR_SALE).type(ItemType.TITLE)
+//                    .saleDeadline(null).point(10L).category(ItemCategory.NEW)
+//                    .description(null).build();
+//            em.merge(item1); em.merge(item2);
+//
+//            Member member = Member.builder()
+//                    .id(0L).profileIcon(item1)
+//                    .profileTitle(item2).email("aaa@email.com")
+//                    .password("1234").birthday(null)
+//                    .nickname("user1").description("hi")
+//                    .profileImageUrl("").status(MemberStatus.Y)
+//                    .alarmAllowance(false).point(0L)
+//                    .loginType(LoginType.SELF).refreshToken("")
+//                    .build();
+//            em.merge(member);
+//
+//            Post post1 = Post.builder()
+//                    .id(0L).member(member)
+//                    .title("게시글1").content("abcdefg")
+//                    .likeCount(10L).view(10L).build();
+//            Post post2 = Post.builder()
+//                    .id(1L).member(member)
+//                    .title("게시글2").content("abcdefg")
+//                    .likeCount(15L).view(15L).build();
+//            Post post3 = Post.builder()
+//                    .id(2L).member(member)
+//                    .title("게시글3").content("abcdefg")
+//                    .likeCount(20L).view(20L).build();
+//            Post post4 = Post.builder()
+//                    .id(3L).member(member)
+//                    .title("게시글4").content("abcdefg")
+//                    .likeCount(20L).view(20L).build();
+//            Post post5 = Post.builder()
+//                    .id(4L).member(member)
+//                    .title("게시글5").content("abcdefg")
+//                    .likeCount(25L).view(25L).build();
+//            Post post6 = Post.builder()
+//                    .id(5L).member(member)
+//                    .title("게시글6").content("abcdefg")
+//                    .likeCount(30L).view(30L).build();
+//            Post post7 = Post.builder()
+//                    .id(6L).member(member)
+//                    .title("게시글7").content("abcdefg")
+//                    .likeCount(35L).view(35L).build();
+//            em.merge(post1); em.merge(post2); em.merge(post3); em.merge(post4); em.merge(post5); em.merge(post6); em.merge(post7);
+//
+//
+//            Address address = addressRepository.findByStateAndDistrict("도쿄도", "시부야구");
+//            Address address2 = Address.builder().state("도쿄도").district("시부야구").build();
+//            em.persist(address2);
+//
+//            Rally rally1 = Rally.builder()
+//                    .item(item1).image(image1).name("최애의 아이")
+//                    .description("환생한 내가 아이돌의 자녀??!!").achieveNumber(10L)
+//                    .pilgrimageNumber(1L).build();
+//            Rally rally2 = Rally.builder()
+//                    .item(item2).image(image2).name("날씨의 아이")
+//                    .description("비야 멈춰라!").achieveNumber(20L)
+//                    .pilgrimageNumber(5L).build();
+//            em.merge(rally1); em.merge(rally2);
+//
+//            Pilgrimage pilgrimage1 = Pilgrimage.builder()
+//                    .address(address2).rally(rally1).virtualImage(image1).realImage(image1)
+//                    .rallyName("최애의 아이").detailAddress("스크램블 교차로1").latitude(1.1).longitude(1.1).build();
+//            Pilgrimage pilgrimage2 = Pilgrimage.builder()
+//                    .address(address2).rally(rally2).virtualImage(image2).realImage(image2)
+//                    .rallyName("최애의 아이").detailAddress("스크램블 교차로2").latitude(1.1).longitude(1.1).build();
+//            em.merge(pilgrimage1); em.merge(pilgrimage2);
+//
+//            GuestBook guestBook1 = GuestBook.builder().id(0L)
+//                    .member(member).pilgrimage(pilgrimage1)
+//                    .title("인증글1").content("인증글내용1").likeCount(5L).view(5L).latitude(1.1).longitude(1.1)
+//                    .build();
+//            GuestBook guestBook2 = GuestBook.builder().id(1L)
+//                    .member(member).pilgrimage(pilgrimage1)
+//                    .title("인증글2").content("인증글내용2").likeCount(10L).view(10L).latitude(1.1).longitude(1.1)
+//                    .build();
+//            GuestBook guestBook3 = GuestBook.builder()
+//                    .member(member).pilgrimage(pilgrimage1)
+//                    .title("인증글3").content("인증글내용3").likeCount(15L).view(15L).latitude(1.1).longitude(1.1)
+//                    .build();
+//            GuestBook guestBook4 = GuestBook.builder()
+//                    .member(member).pilgrimage(pilgrimage2)
+//                    .title("인증글4").content("인증글내용4").likeCount(20L).view(20L).latitude(1.1).longitude(1.1)
+//                    .build();
+//            GuestBook guestBook5 = GuestBook.builder()
+//                    .member(member).pilgrimage(pilgrimage2)
+//                    .title("인증글5").content("인증글내용5").likeCount(20L).view(20L).latitude(1.1).longitude(1.1)
+//                    .build();
+//            GuestBook guestBook6 = GuestBook.builder()
+//                    .member(member).pilgrimage(pilgrimage2)
+//                    .title("인증글6").content("인증글내용6").likeCount(25L).view(25L).latitude(1.1).longitude(1.1)
+//                    .build();
+//            GuestBook guestBook7 = GuestBook.builder()
+//                    .member(member).pilgrimage(pilgrimage2)
+//                    .title("인증글7").content("인증글내용7").likeCount(30L).view(30L).latitude(1.1).longitude(1.1)
+//                    .build();
+//            em.merge(guestBook1);em.merge(guestBook2); em.merge(guestBook3); em.merge(guestBook4); em.merge(guestBook5); em.merge(guestBook6); em.merge(guestBook7);
+//
+//            Comment comment1 = Comment.builder()
+//                    .member(member).post(null).guestBook(guestBook1).content("G댓글1").build();
+//            Comment comment2 = Comment.builder()
+//                    .member(member).post(null).guestBook(guestBook1).content("G댓글2").build();
+//            Comment comment3 = Comment.builder()
+//                    .member(member).post(null).guestBook(guestBook1).content("G댓글3").build();
+//            Comment comment4 = Comment.builder()
+//                    .member(member).post(post1).guestBook(null).content("P댓글4").build();
+//            Comment comment5 = Comment.builder()
+//                    .member(member).post(post1).guestBook(null).content("P댓글5").build();
+//            Comment comment6 = Comment.builder()
+//                    .member(member).post(post1).guestBook(null).content("P댓글6").build();
+//            em.merge(comment1); em.merge(comment2);em.merge(comment3);em.merge(comment4);em.merge(comment5);em.merge(comment6);
+//        }
 
         public void initMember(){
             createMember("1");
         }
 
-        public void initRallyAndPilgrimage(){
+        public void initAddress(){
             Address addressSibuya = createAddress("도쿄도", "시부야구");
             Address addressShinjuku = createAddress("도쿄도", "신주쿠구");
             Address addressMinato = createAddress("도쿄도", "미나토구");
+        }
+
+        public void initWeatheringWithYou(){
+            Address addressSibuya = addressRepository.findById(1L).orElse(null);
+            Address addressShinjuku = addressRepository.findById(2L).orElse(null);
+            Address addressMinato = addressRepository.findById(3L).orElse(null);
+
             Rally rally = createRally("날씨의 아이", "천비가 멈추지 않던 여름날, 고향을 떠나 도쿄로 온 가출 소년 호다카는 우연히 비를 멈추게 하는 능력을 가진 신비한 소녀 히나를 만난다. 히나의 능력을 알게 된 호다카는 그 능력을 사용해 돈을 벌 계획을 세운다. 매일 내리는 비로 우울해하는 도쿄 사람들은 히나의 능력으로 인해 행복감을 되찾게 되지만, 호다카와 히나는 뜻밖의 비밀을 마주하게 된다.");
-            Pilgrimage pilgrimage1 = createPilgrimage(addressSibuya, rally, "시부야 스크램블교차로");
-            Pilgrimage pilgrimage2 = createPilgrimage(addressMinato, rally, "롯폰기 힐즈 스카이덱 전망대");
-            Pilgrimage pilgrimage3 = createPilgrimage(addressMinato, rally, "오다이바 해변공원");
-            Pilgrimage pilgrimage4 = createPilgrimage(addressShinjuku, rally, "맥도날드 신주쿠 역전점");
+            Pilgrimage pilgrimage1 = createPilgrimage(addressShinjuku, rally, "맥도날드 세이부 신주쿠역 앞점");
+            Pilgrimage pilgrimage2 = createPilgrimage(addressShinjuku, rally, "아타미 빌딩");
+            Pilgrimage pilgrimage3 = createPilgrimage(addressSibuya, rally, "시부야 스크램블 교차로");
+            Pilgrimage pilgrimage4 = createPilgrimage(addressMinato, rally, "시바 공원");
+        }
+
+        public void initOshiNoKo(){
+            Address addressSibuya = addressRepository.findById(1L).orElse(null);
+            Address addressShinjuku = addressRepository.findById(2L).orElse(null);
+            Rally rally = createRally("최애의 아이", "‘최애의 아이’는 주인공인 호시노 루비, 호시노 아쿠아를 비롯한 연예계 친구들이 다니고 있는 학교나 사무실의 위치, 자주 등장하는 배경 등을 미루어보았을 때 도쿄도, 특히 메구로구 중심으로 배경지가 설정되어 있음을 알 수 있다. 특히 ‘오늘은 달콤하게’ 촬영 장면의 배경이 된 오다이바와 도쿄 돔, 무도관 등을 제외하면 메구로-신주쿠-시부야구의 도쿄 서쪽이 대부분이므로 한 번에 여러 장소를 둘러보기 좋다.");
+            Pilgrimage pilgrimage1 = createPilgrimage(addressSibuya, rally, "에비스 가든 플레이스");
+            Pilgrimage pilgrimage2 = createPilgrimage(addressSibuya, rally, "패밀리 마트 시부야 공원 도오리점");
+            Pilgrimage pilgrimage3 = createPilgrimage(addressSibuya, rally, "에비스 미나미 2공원");
+            Pilgrimage pilgrimage4 = createPilgrimage(addressSibuya, rally, "스타벅스 시부야 츠타야점");
+            Pilgrimage pilgrimage5 = createPilgrimage(addressShinjuku, rally, "쿠시카츠 타나카 신주쿠산초메점");
         }
 
         public Member createMember(String number){

--- a/src/main/java/com/favoriteplace/InitDB.java
+++ b/src/main/java/com/favoriteplace/InitDB.java
@@ -30,6 +30,7 @@ public class InitDB {
         initService.initAddress();
         initService.initWeatheringWithYou();
         initService.initOshiNoKo();
+        initService.initJujutsuKaisen();
 //        initService.initDB();
     }
 
@@ -201,6 +202,18 @@ public class InitDB {
             Pilgrimage pilgrimage3 = createPilgrimage(addressSibuya, rally, "에비스 미나미 2공원");
             Pilgrimage pilgrimage4 = createPilgrimage(addressSibuya, rally, "스타벅스 시부야 츠타야점");
             Pilgrimage pilgrimage5 = createPilgrimage(addressShinjuku, rally, "쿠시카츠 타나카 신주쿠산초메점");
+        }
+
+        public void initJujutsuKaisen(){
+            Address addressSibuya = addressRepository.findById(1L).orElse(null);
+            Address addressShinjuku = addressRepository.findById(2L).orElse(null);
+            Address addressMinato = addressRepository.findById(3L).orElse(null);
+            Rally rally = createRally("주술회전", "‘주술고전’이 도쿄와 교토에 하나씩 있는 만큼, 1기는 도쿄도와 교토부를 배경으로 하는 장면이 많다. 1기 오프닝의 배경 역시 도쿄 스카이트리, 신주쿠의 눈 등 다양한 도쿄의 장소를 담아내기도 하였다. 2기는 부제목이 ‘시부야 사변’인 만큼 도쿄도 시부야구를 배경으로 스토리가 진행되었기에 시부야의 실제 장소가 여럿 등장한다.");
+            Pilgrimage pilgrimage1 = createPilgrimage(addressShinjuku, rally, "KFC 니시신주쿠점 건너편");
+            Pilgrimage pilgrimage2 = createPilgrimage(addressSibuya, rally, "시부야 히카리에 입구");
+            Pilgrimage pilgrimage3 = createPilgrimage(addressMinato, rally, "롯폰기 힐즈 아레나");
+            Pilgrimage pilgrimage4 = createPilgrimage(addressMinato, rally, "도쿄 스카이트리");
+            Pilgrimage pilgrimage5 = createPilgrimage(addressMinato, rally, "신주쿠의 눈");
         }
 
         public Member createMember(String number){

--- a/src/main/java/com/favoriteplace/InitDB.java
+++ b/src/main/java/com/favoriteplace/InitDB.java
@@ -13,6 +13,7 @@ import com.favoriteplace.app.domain.travel.Rally;
 import com.favoriteplace.app.repository.AddressRepository;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
+import jdk.jfr.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,8 +50,7 @@ public class InitDB {
                     .image(image1).name("icon1")
                     .status(SaleStatus.NOT_FOR_SALE).type(ItemType.ICON)
                     .saleDeadline(null).point(10L).category(ItemCategory.NEW)
-                    .saleDeadline(null).point(null)
-                    .description(null).build();
+                    .saleDeadline(null).description(null).build();
             Item item2 = Item.builder()
                     .image(image2).name("title1")
                     .status(SaleStatus.NOT_FOR_SALE).type(ItemType.TITLE)
@@ -186,8 +186,8 @@ public class InitDB {
             Image image1 = createImage("imgIcon"+number);
             Image image2 = createImage("imgTitle"+number);
 
-            Item item1 = createItem(image1, "icon"+number, ItemType.ICON);
-            Item item2 = createItem(image2, "title"+number, ItemType.TITLE);
+            Item item1 = createItem(image1, "icon"+number, ItemType.ICON, ItemCategory.NEW);
+            Item item2 = createItem(image2, "title"+number, ItemType.TITLE, ItemCategory.NEW);
 
             Member member = Member.builder()
                     .id(0L)
@@ -212,7 +212,7 @@ public class InitDB {
         public Rally createRally(String name, String description){
             Image image1 = createImage("rallyItemImg");
             Image animeImg = createImage("animeImg");
-            Item item1 = createItem(image1, "rallyTitle", ItemType.TITLE);
+            Item item1 = createItem(image1, "rallyTitle", ItemType.TITLE, ItemCategory.NEW);
             Rally rally = Rally.builder()
                     .item(item1)
                     .image(animeImg)
@@ -252,15 +252,16 @@ public class InitDB {
             em.persist(address);
             return address;
         }
-        private Item createItem(Image image1, String name, ItemType type) {
+        private Item createItem(Image image1, String name, ItemType type, ItemCategory itemCategory) {
             Item item = Item.builder()
                     .image(image1)
                     .name(name)
                     .status(SaleStatus.NOT_FOR_SALE)
                     .type(type)
                     .saleDeadline(null)
-                    .point(null)
+                    .point(0L)
                     .description(null)
+                    .category(itemCategory)
                     .build();
             em.persist(item);
             return item;

--- a/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
@@ -4,6 +4,7 @@ import com.favoriteplace.app.domain.Member;
 import com.favoriteplace.app.dto.CommonResponseDto;
 import com.favoriteplace.app.dto.travel.PilgrimageDto;
 import com.favoriteplace.app.dto.travel.RallyDto;
+import com.favoriteplace.app.service.PilgrimageCommandService;
 import com.favoriteplace.app.service.PilgrimageQueryService;
 import com.favoriteplace.global.exception.ErrorCode;
 import com.favoriteplace.global.exception.RestApiException;
@@ -22,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PilgrimageApiController {
     private final PilgrimageQueryService pilgrimageQueryService;
+    private final PilgrimageCommandService pilgrimageCommandService;
     private final SecurityUtil securityUtil;
 
     // 내 성지순례 + 인증글 모아보기(메인)
@@ -92,18 +94,21 @@ public class PilgrimageApiController {
     // 랠리 찜하기
     @PostMapping("/{rally_id}")
     public CommonResponseDto.PostResponseDto likeToRally(@PathVariable("rally_id")Long rallyId){
-        return null;
+        Member member = securityUtil.getUser();
+        return pilgrimageCommandService.likeToRally(rallyId, member);
     }
 
     // 성지순례 장소 방문 인증하기
-    @PostMapping("/certified/{pilgrimage_id")
+    @PostMapping("/certified/{pilgrimage_id}")
     public CommonResponseDto.PostResponseDto certifyToPilgrimage(@PathVariable("pilgrimage_id")Long pilgrimageId){
-        return null;
+        Member member = securityUtil.getUser();
+        return pilgrimageCommandService.certifyToPilgrimage(pilgrimageId, member);
     }
 
     // 성지순례 장소 방문 인증글 작성하기
     @PostMapping("/guestbooks/{pilgrimage_id}")
     public CommonResponseDto.PostResponseDto postToPilgrimage(@PathVariable("pilgrimage_id")Long pilgrimageId){
-        return null;
+        Member member = securityUtil.getUser();
+        return pilgrimageCommandService.postToPilgrimage(pilgrimageId, member);
     }
 }

--- a/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
@@ -26,6 +26,8 @@ public class PilgrimageApiController {
     private final PilgrimageCommandService pilgrimageCommandService;
     private final SecurityUtil securityUtil;
 
+    /* ================ GET ================ */
+
     // 내 성지순례 + 인증글 모아보기(메인)
     // 회원 + 비회원
     @GetMapping("")
@@ -91,6 +93,8 @@ public class PilgrimageApiController {
                 pilgrimageId, member);
     }
 
+    /* ================ POST ================ */
+
     // 랠리 찜하기
     @PostMapping("/{rally_id}")
     public CommonResponseDto.PostResponseDto likeToRally(@PathVariable("rally_id")Long rallyId){
@@ -100,9 +104,11 @@ public class PilgrimageApiController {
 
     // 성지순례 장소 방문 인증하기
     @PostMapping("/certified/{pilgrimage_id}")
-    public CommonResponseDto.PostResponseDto certifyToPilgrimage(@PathVariable("pilgrimage_id")Long pilgrimageId){
+    public CommonResponseDto.PostResponseDto certifyToPilgrimage(
+            @PathVariable("pilgrimage_id")Long pilgrimageId,
+            @RequestBody PilgrimageDto.PilgrimageCertifyRequestDto form){
         Member member = securityUtil.getUser();
-        return pilgrimageCommandService.certifyToPilgrimage(pilgrimageId, member);
+        return pilgrimageCommandService.certifyToPilgrimage(pilgrimageId, member, form);
     }
 
     // 성지순례 장소 방문 인증글 작성하기

--- a/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
@@ -89,8 +89,7 @@ public class PilgrimageApiController {
     public PilgrimageDto.PilgrimageDetailDto getPilgrimageDetail(@PathVariable("pilgrimageId")Long pilgrimageId){
         // Jwt AuthenticationFilter에 엔드포인트 추가
         Member member = securityUtil.getUser();
-        return pilgrimageQueryService.getPilgrimageDetail(
-                pilgrimageId, member);
+        return pilgrimageQueryService.getPilgrimageDetail(pilgrimageId, member);
     }
 
     /* ================ POST ================ */

--- a/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
@@ -1,6 +1,7 @@
 package com.favoriteplace.app.controller;
 
 import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.dto.CommonResponseDto;
 import com.favoriteplace.app.dto.travel.PilgrimageDto;
 import com.favoriteplace.app.dto.travel.RallyDto;
 import com.favoriteplace.app.service.PilgrimageQueryService;
@@ -11,10 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -84,10 +82,28 @@ public class PilgrimageApiController {
     // 성지순례 랠리 장소 상세
     // 회원
     @GetMapping("/detail/{pilgrimageId}")
-        public PilgrimageDto.PilgrimageDetailDto getPilgrimageDetail(@PathVariable("pilgrimageId")Long pilgrimageId){
+    public PilgrimageDto.PilgrimageDetailDto getPilgrimageDetail(@PathVariable("pilgrimageId")Long pilgrimageId){
         // Jwt AuthenticationFilter에 엔드포인트 추가
         Member member = securityUtil.getUser();
         return pilgrimageQueryService.getPilgrimageDetail(
                 pilgrimageId, member);
+    }
+
+    // 랠리 찜하기
+    @PostMapping("/{rally_id}")
+    public CommonResponseDto.PostResponseDto likeToRally(@PathVariable("rally_id")Long rallyId){
+        return null;
+    }
+
+    // 성지순례 장소 방문 인증하기
+    @PostMapping("/certified/{pilgrimage_id")
+    public CommonResponseDto.PostResponseDto certifyToPilgrimage(@PathVariable("pilgrimage_id")Long pilgrimageId){
+        return null;
+    }
+
+    // 성지순례 장소 방문 인증글 작성하기
+    @PostMapping("/guestbooks/{pilgrimage_id}")
+    public CommonResponseDto.PostResponseDto postToPilgrimage(@PathVariable("pilgrimage_id")Long pilgrimageId){
+        return null;
     }
 }

--- a/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
@@ -103,7 +103,7 @@ public class PilgrimageApiController {
 
     // 성지순례 장소 방문 인증하기
     @PostMapping("/certified/{pilgrimage_id}")
-    public CommonResponseDto.PostResponseDto certifyToPilgrimage(
+    public CommonResponseDto.RallyResponseDto certifyToPilgrimage(
             @PathVariable("pilgrimage_id")Long pilgrimageId,
             @RequestBody PilgrimageDto.PilgrimageCertifyRequestDto form){
         Member member = securityUtil.getUser();

--- a/src/main/java/com/favoriteplace/app/converter/CommonConverter.java
+++ b/src/main/java/com/favoriteplace/app/converter/CommonConverter.java
@@ -9,4 +9,12 @@ public class CommonConverter {
                 .message(message)
                 .build();
     }
+
+    public static CommonResponseDto.RallyResponseDto toRallyResponseDto(Boolean success, Boolean isComplete, String message){
+        return CommonResponseDto.RallyResponseDto.builder()
+                .success(success)
+                .isComplete(isComplete)
+                .message(message)
+                .build();
+    }
 }

--- a/src/main/java/com/favoriteplace/app/converter/CommonConverter.java
+++ b/src/main/java/com/favoriteplace/app/converter/CommonConverter.java
@@ -1,0 +1,12 @@
+package com.favoriteplace.app.converter;
+
+import com.favoriteplace.app.dto.CommonResponseDto;
+
+public class CommonConverter {
+    public static CommonResponseDto.PostResponseDto toPostResponseDto(Boolean success, String message){
+        return CommonResponseDto.PostResponseDto.builder()
+                .success(success)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/favoriteplace/app/converter/PilgrimageConverter.java
+++ b/src/main/java/com/favoriteplace/app/converter/PilgrimageConverter.java
@@ -22,6 +22,7 @@ public class PilgrimageConverter {
                 .address(pilgrimage.getDetailAddress())
                 .latitude(pilgrimage.getLatitude())
                 .longitude(pilgrimage.getLongitude())
+                .isCertified(true)
                 .isWritable(false)
                 .isMultiWritable(false)
                 .build();

--- a/src/main/java/com/favoriteplace/app/converter/PointHistoryConverter.java
+++ b/src/main/java/com/favoriteplace/app/converter/PointHistoryConverter.java
@@ -1,0 +1,19 @@
+package com.favoriteplace.app.converter;
+
+import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.domain.enums.PointType;
+import com.favoriteplace.app.domain.item.PointHistory;
+
+import java.time.LocalDateTime;
+
+public class PointHistoryConverter {
+    public static PointHistory toPointHistory(Member member, Long point, PointType type){
+        member.updatePoint(point);
+        return PointHistory.builder()
+                .member(member)
+                .point(point)
+                .dealtAt(LocalDateTime.now())
+                .pointType(type)
+                .build();
+    }
+}

--- a/src/main/java/com/favoriteplace/app/domain/Member.java
+++ b/src/main/java/com/favoriteplace/app/domain/Member.java
@@ -77,4 +77,7 @@ public class Member extends BaseTimeEntity {
         this.refreshToken = refreshToken;
     }
 
+    public void updatePoint(Long point) {
+        this.point += point;
+    }
 }

--- a/src/main/java/com/favoriteplace/app/domain/enums/RallyVersion.java
+++ b/src/main/java/com/favoriteplace/app/domain/enums/RallyVersion.java
@@ -1,0 +1,13 @@
+package com.favoriteplace.app.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public enum RallyVersion {
+    v1("BETA 1.0");
+    private final String version;
+}

--- a/src/main/java/com/favoriteplace/app/domain/item/PointHistory.java
+++ b/src/main/java/com/favoriteplace/app/domain/item/PointHistory.java
@@ -41,7 +41,7 @@ public class PointHistory {
     private Long point;
 
     @Column(nullable = false)
-    private LocalDateTime dealt_at;
+    private LocalDateTime dealtAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/favoriteplace/app/domain/travel/CompleteRally.java
+++ b/src/main/java/com/favoriteplace/app/domain/travel/CompleteRally.java
@@ -1,0 +1,27 @@
+package com.favoriteplace.app.domain.travel;
+
+import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.domain.common.BaseTimeEntity;
+import com.favoriteplace.app.domain.enums.RallyVersion;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompleteRally extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="complete_rally_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rally_id", nullable = false)
+    private Rally rally;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+    @Enumerated(EnumType.STRING)
+    private RallyVersion version;
+}

--- a/src/main/java/com/favoriteplace/app/domain/travel/Rally.java
+++ b/src/main/java/com/favoriteplace/app/domain/travel/Rally.java
@@ -51,4 +51,5 @@ public class Rally extends BaseTimeEntity {
     public void addPilgrimage(){
         this.pilgrimageNumber += 1;
     }
+    public void addAchieveNumber() { this.achieveNumber += 1; }
 }

--- a/src/main/java/com/favoriteplace/app/dto/CommonResponseDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/CommonResponseDto.java
@@ -1,0 +1,17 @@
+package com.favoriteplace.app.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CommonResponseDto {
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PostResponseDto{
+        Boolean success;
+        String message;
+    }
+}

--- a/src/main/java/com/favoriteplace/app/dto/CommonResponseDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/CommonResponseDto.java
@@ -14,4 +14,13 @@ public class CommonResponseDto {
         Boolean success;
         String message;
     }
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RallyResponseDto {
+        Boolean success;
+        String message;
+        Boolean isComplete;
+    }
 }

--- a/src/main/java/com/favoriteplace/app/dto/travel/PilgrimageDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/travel/PilgrimageDto.java
@@ -23,6 +23,7 @@ public class PilgrimageDto {
         String address;
         Double latitude;
         Double longitude;
+        Boolean isCertified;
         Boolean isWritable;
         Boolean isMultiWritable;
     }

--- a/src/main/java/com/favoriteplace/app/dto/travel/PilgrimageDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/travel/PilgrimageDto.java
@@ -5,12 +5,15 @@ import lombok.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
 public class PilgrimageDto {
     @Builder
     @Getter
     @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
     public static class PilgrimageDetailDto {
         String rallyName;
         Long pilgrimageNumber;
@@ -26,8 +29,8 @@ public class PilgrimageDto {
 
     @Builder
     @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
     public static class MyPilgrimageDto {
         Long likedRallySize;
         List<LikedRallyDto> likedRally = new ArrayList<>();
@@ -37,8 +40,8 @@ public class PilgrimageDto {
 
     @Builder
     @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
     public static class LikedRallyDto {
         Long id;
         String name;
@@ -47,8 +50,8 @@ public class PilgrimageDto {
 
     @Builder
     @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
     public static class MyGuestBookDto {
         Long id;
         String title;
@@ -59,17 +62,17 @@ public class PilgrimageDto {
 
     @Builder
     @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
     public static class PilgrimageCategoryRegionDto {
         String state;
-        List<PilgrimageAddressDetailDto> detail = new ArrayList<>();
+        List<PilgrimageAddressDetailDto> detail;
     }
 
     @Builder
     @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
     public static class PilgrimageAddressDetailDto {
         Long id;
         String district;
@@ -77,13 +80,21 @@ public class PilgrimageDto {
 
     @Builder
     @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
     public static class PilgrimageCategoryRegionDetailDto {
         Long id;
         String title;
         String detailAddress;
         Double latitude;
         Double longitude;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = PROTECTED)
+    @AllArgsConstructor(access = PRIVATE)
+    public static class PilgrimageCertifyRequestDto{
+        Long longitude;
+        Long latitude;
     }
 }

--- a/src/main/java/com/favoriteplace/app/repository/CompleteRallyRepository.java
+++ b/src/main/java/com/favoriteplace/app/repository/CompleteRallyRepository.java
@@ -1,0 +1,12 @@
+package com.favoriteplace.app.repository;
+
+import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.domain.travel.CompleteRally;
+import com.favoriteplace.app.domain.travel.Rally;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CompleteRallyRepository extends JpaRepository<CompleteRally, Long> {
+    CompleteRally findByMemberAndRally(Member member, Rally rally);
+}

--- a/src/main/java/com/favoriteplace/app/repository/PointHistoryRepository.java
+++ b/src/main/java/com/favoriteplace/app/repository/PointHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.favoriteplace.app.repository;
+
+import com.favoriteplace.app.domain.item.PointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+}

--- a/src/main/java/com/favoriteplace/app/repository/VisitedPilgrimageRepository.java
+++ b/src/main/java/com/favoriteplace/app/repository/VisitedPilgrimageRepository.java
@@ -5,15 +5,24 @@ import com.favoriteplace.app.domain.travel.Pilgrimage;
 import com.favoriteplace.app.domain.travel.Rally;
 import com.favoriteplace.app.domain.travel.VisitedPilgrimage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
 @Repository
 public interface VisitedPilgrimageRepository extends JpaRepository<VisitedPilgrimage, Long> {
     List<VisitedPilgrimage> findByMemberIdOrderByModifiedAtDesc(Long memberId);
-    List<VisitedPilgrimage> findByMemberAndPilgrimage_Rally(Member member, Rally rally);
-    List<VisitedPilgrimage> findDistinctByMemberAndPilgrimage_Rally(Member member, Rally rally);
+    @Query("""
+    select count(distinct p.id)
+    from Rally r
+    join Pilgrimage p on r.id = p.rally.id
+    join VisitedPilgrimage vp on p.id = vp.pilgrimage.id
+    and vp.member.id = :memberId and r.id = :rallyId
+    """)
+    Long findByDistinctCount(@Param("memberId") Long memberId, @Param("rallyId") Long rallyId);
     List<VisitedPilgrimage> findByPilgrimageAndMemberOrderByCreatedAtDesc(Pilgrimage pilgrimage, Member member);
     Long countByMemberIdAndPilgrimageIdIn(Long memberId, List<Long> pilgrimageIds);
 }

--- a/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
+++ b/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
@@ -1,9 +1,67 @@
 package com.favoriteplace.app.service;
 
+import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.domain.travel.LikedRally;
+import com.favoriteplace.app.domain.travel.Rally;
+import com.favoriteplace.app.dto.CommonResponseDto;
+import com.favoriteplace.app.repository.LikedRallyRepository;
+import com.favoriteplace.app.repository.RallyRepository;
+import com.favoriteplace.global.exception.ErrorCode;
+import com.favoriteplace.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PilgrimageCommandService {
+    private final RallyRepository rallyRepository;
+    private final LikedRallyRepository likedRallyRepository;
+    /***
+     * 랠리 찜하기
+     * @param rallyId 랠리 아이디
+     * @param member 찜한 사용자
+     * @return
+     */
+    public CommonResponseDto.PostResponseDto likeToRally(Long rallyId, Member member) {
+        Rally rally = rallyRepository.findById(rallyId).orElseThrow(
+                ()->new RestApiException(ErrorCode.RALLY_NOT_FOUND));
+        LikedRally likedRally = likedRallyRepository.findByRallyAndMember(rally, member);
+        if (likedRally == null) {
+            LikedRally newLikedRally = LikedRally.builder()
+                    .rally(rally)
+                    .member(member)
+                    .build();
+            likedRallyRepository.save(newLikedRally);
+            return CommonResponseDto.PostResponseDto.builder()
+                    .success(true)
+                    .message("찜 목록에 추가됐습니다.")
+                    .build();
+        } else {
+            likedRallyRepository.delete(likedRally);
+            return CommonResponseDto.PostResponseDto.builder()
+                    .success(true)
+                    .message("찜을 취소했습니다.")
+                    .build();
+        }
+    }
+
+    /***
+     * 성지순례 방문 인증하기
+     * @param pilgrimageId 성지순례 아이디
+     * @param member 인증한 사용자
+     * @return
+     */
+    public CommonResponseDto.PostResponseDto certifyToPilgrimage(Long pilgrimageId, Member member) {
+        return null;
+    }
+
+    /***
+     * 성지순례 방문 인증글 작성하기
+     * @param pilgrimageId 성지순례 아이디
+     * @param member 인증한 사용자
+     * @return
+     */
+    public CommonResponseDto.PostResponseDto postToPilgrimage(Long pilgrimageId, Member member) {
+        return null;
+    }
 }

--- a/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
+++ b/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
@@ -78,12 +78,12 @@ public class PilgrimageCommandService {
                 throw new RestApiException(ErrorCode.PILGRIMAGE_CAN_NOT_CERTIFIED);
 
             // 성공 시 포인트 지급 -> 15p & visitedPilgrimage 추가
-            VisitedPilgrimage newVisited = VisitedPilgrimage.builder()
-                    .pilgrimage(pilgrimage)
-                    .member(member)
-                    .build();
+            VisitedPilgrimage newVisited = VisitedPilgrimage.builder().pilgrimage(pilgrimage).member(member).build();
             visitedPilgrimageRepository.save(newVisited);
-            PointHistoryConverter.toPointHistory(member, 15L, PointType.ACQUIRE);
+            pointHistoryRepository.save(PointHistoryConverter.toPointHistory(member, 15L, PointType.ACQUIRE));
+            // 전체 랠리를 성공했는지 조회 후 맞다면... ->
+
+
             return CommonConverter.toPostResponseDto(true, "인증에 성공했습니다.");
         } else throw new RestApiException(ErrorCode.PILGRIMAGE_ALREADY_CERTIFIED);
     }

--- a/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
+++ b/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
@@ -81,6 +81,7 @@ public class PilgrimageCommandService {
             VisitedPilgrimage newVisited = VisitedPilgrimage.builder().pilgrimage(pilgrimage).member(member).build();
             visitedPilgrimageRepository.save(newVisited);
             pointHistoryRepository.save(PointHistoryConverter.toPointHistory(member, 15L, PointType.ACQUIRE));
+
             // 전체 랠리를 성공했는지 조회 후 맞다면... ->
 
 

--- a/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
+++ b/src/main/java/com/favoriteplace/app/service/PilgrimageCommandService.java
@@ -1,21 +1,35 @@
 package com.favoriteplace.app.service;
 
+import com.favoriteplace.app.converter.CommonConverter;
+import com.favoriteplace.app.converter.PointHistoryConverter;
 import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.domain.enums.PointType;
+import com.favoriteplace.app.domain.item.PointHistory;
 import com.favoriteplace.app.domain.travel.LikedRally;
+import com.favoriteplace.app.domain.travel.Pilgrimage;
 import com.favoriteplace.app.domain.travel.Rally;
+import com.favoriteplace.app.domain.travel.VisitedPilgrimage;
 import com.favoriteplace.app.dto.CommonResponseDto;
-import com.favoriteplace.app.repository.LikedRallyRepository;
-import com.favoriteplace.app.repository.RallyRepository;
+import com.favoriteplace.app.dto.travel.PilgrimageDto;
+import com.favoriteplace.app.repository.*;
 import com.favoriteplace.global.exception.ErrorCode;
 import com.favoriteplace.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class PilgrimageCommandService {
     private final RallyRepository rallyRepository;
+    private final PilgrimageRepository pilgrimageRepository;
     private final LikedRallyRepository likedRallyRepository;
+    private final VisitedPilgrimageRepository visitedPilgrimageRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
     /***
      * 랠리 찜하기
      * @param rallyId 랠리 아이디
@@ -26,22 +40,17 @@ public class PilgrimageCommandService {
         Rally rally = rallyRepository.findById(rallyId).orElseThrow(
                 ()->new RestApiException(ErrorCode.RALLY_NOT_FOUND));
         LikedRally likedRally = likedRallyRepository.findByRallyAndMember(rally, member);
+
         if (likedRally == null) {
             LikedRally newLikedRally = LikedRally.builder()
                     .rally(rally)
                     .member(member)
                     .build();
             likedRallyRepository.save(newLikedRally);
-            return CommonResponseDto.PostResponseDto.builder()
-                    .success(true)
-                    .message("찜 목록에 추가됐습니다.")
-                    .build();
+            return CommonConverter.toPostResponseDto(true, "찜 목록에 추가됐습니다.");
         } else {
             likedRallyRepository.delete(likedRally);
-            return CommonResponseDto.PostResponseDto.builder()
-                    .success(true)
-                    .message("찜을 취소했습니다.")
-                    .build();
+            return CommonConverter.toPostResponseDto(true, "찜을 취소했습니다.");
         }
     }
 
@@ -51,8 +60,32 @@ public class PilgrimageCommandService {
      * @param member 인증한 사용자
      * @return
      */
-    public CommonResponseDto.PostResponseDto certifyToPilgrimage(Long pilgrimageId, Member member) {
-        return null;
+    public CommonResponseDto.PostResponseDto certifyToPilgrimage(Long pilgrimageId,
+                                                                 Member member,
+                                                                 PilgrimageDto.PilgrimageCertifyRequestDto form) {
+        Pilgrimage pilgrimage = pilgrimageRepository.findById(pilgrimageId).orElseThrow(
+                ()->new RestApiException(ErrorCode.PILGRIMAGE_NOT_FOUND));
+
+        // 24시간 이내 방문이력 확인
+        List<VisitedPilgrimage> visitedPilgrimages = visitedPilgrimageRepository
+                .findByPilgrimageAndMemberOrderByCreatedAtDesc(pilgrimage, member);
+
+        if (visitedPilgrimages.isEmpty()
+                || (!visitedPilgrimages.isEmpty() && visitedPilgrimages.get(0).getPilgrimage().getCreatedAt().plusHours(24L).isBefore(LocalDateTime.now()))) {
+            // 현재 좌표가 성지순례 장소 좌표 기준 +-0.00135 이내인지 확인
+            if (pilgrimage.getLatitude() + 0.00135 < form.getLatitude() || pilgrimage.getLatitude() - 0.00135 > form.getLatitude()
+                    || pilgrimage.getLongitude() + 0.00135 < form.getLongitude() || pilgrimage.getLongitude() - 0.00135 > form.getLongitude())
+                throw new RestApiException(ErrorCode.PILGRIMAGE_CAN_NOT_CERTIFIED);
+
+            // 성공 시 포인트 지급 -> 15p & visitedPilgrimage 추가
+            VisitedPilgrimage newVisited = VisitedPilgrimage.builder()
+                    .pilgrimage(pilgrimage)
+                    .member(member)
+                    .build();
+            visitedPilgrimageRepository.save(newVisited);
+            PointHistoryConverter.toPointHistory(member, 15L, PointType.ACQUIRE);
+            return CommonConverter.toPostResponseDto(true, "인증에 성공했습니다.");
+        } else throw new RestApiException(ErrorCode.PILGRIMAGE_ALREADY_CERTIFIED);
     }
 
     /***

--- a/src/main/java/com/favoriteplace/app/service/PilgrimageQueryService.java
+++ b/src/main/java/com/favoriteplace/app/service/PilgrimageQueryService.java
@@ -129,9 +129,13 @@ public class PilgrimageQueryService {
                 .findByDistinctCount(member.getId(), pilgrimage.getRally().getId());
         PilgrimageDto.PilgrimageDetailDto result = PilgrimageConverter.toPilgrimageDetailDto(pilgrimage, visitedPilgrimages);
 
-        // 이 성지순례에 인증 기록이 있다면 isWritable -> true
         List<VisitedPilgrimage> visitedLog = visitedPilgrimageRepository
                 .findByPilgrimageAndMemberOrderByCreatedAtDesc(pilgrimage, member);
+        // 24시간 이내 인증 기록이 있는지 확인
+        if (!visitedLog.isEmpty() && visitedLog.get(0).getCreatedAt().plusHours(24L).isAfter(LocalDateTime.now())) {
+            result.setIsCertified(false);
+        }
+        // 이 성지순례에 인증 기록이 있다면 isWritable -> true
         if (visitedLog.size() >= 1) {
             result.setIsWritable(true);
         }

--- a/src/main/java/com/favoriteplace/app/service/PilgrimageQueryService.java
+++ b/src/main/java/com/favoriteplace/app/service/PilgrimageQueryService.java
@@ -54,12 +54,12 @@ public class PilgrimageQueryService {
             return RallyConverter.toRallyDetailResponseDto(rally, 0L, false, false);
         }
         LikedRally isLikeList = likedRallyRepository.findByRallyAndMember(rally, member);
-        List<VisitedPilgrimage> pilgrimageNumber = visitedPilgrimageRepository
-                .findByMemberAndPilgrimage_Rally(member, rally);
+        Long pilgrimageNumber = visitedPilgrimageRepository
+                .findByDistinctCount(member.getId(), rally.getId());
         if (isLikeList == null) {
-            return RallyConverter.toRallyDetailResponseDto(rally, Long.valueOf(pilgrimageNumber.size()), false, true);
+            return RallyConverter.toRallyDetailResponseDto(rally, pilgrimageNumber, false, true);
         }
-        return RallyConverter.toRallyDetailResponseDto(rally, Long.valueOf(pilgrimageNumber.size()), true, true);
+        return RallyConverter.toRallyDetailResponseDto(rally, pilgrimageNumber, true, true);
     }
 
     /***
@@ -87,12 +87,12 @@ public class PilgrimageQueryService {
                     .stream()
                     .forEach(rallyAddressPilgrimageDto ->
                             checkVisitedPilgrimage(rallyAddressPilgrimageDto, member)));
-            return RallyConverter.toRallyAddressListDto(rally, addressDtoList, 0L);
+            Long myPilgrimageNumber = visitedPilgrimageRepository
+                    .findByDistinctCount(member.getId(), rally.getId());
+            return RallyConverter.toRallyAddressListDto(rally, addressDtoList, myPilgrimageNumber);
         }
         // RallyAddressListDto 생성 후 반환하기
-        Long myPilgrimageNumber = Long.valueOf(visitedPilgrimageRepository
-                .findDistinctByMemberAndPilgrimage_Rally(member, rally).size());
-        return RallyConverter.toRallyAddressListDto(rally, addressDtoList, myPilgrimageNumber);
+        return RallyConverter.toRallyAddressListDto(rally, addressDtoList, 0L);
     }
 
     private void checkVisitedPilgrimage(RallyDto.RallyAddressPilgrimageDto dto, Member member){
@@ -125,9 +125,9 @@ public class PilgrimageQueryService {
     public PilgrimageDto.PilgrimageDetailDto getPilgrimageDetail(Long pilgrimageId, Member member) {
         Pilgrimage pilgrimage = pilgrimageRepository.findById(pilgrimageId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.PILGRIMAGE_NOT_FOUND));
-        List<VisitedPilgrimage> visitedPilgrimages = visitedPilgrimageRepository
-                .findDistinctByMemberAndPilgrimage_Rally(member, pilgrimage.getRally());
-        PilgrimageDto.PilgrimageDetailDto result = PilgrimageConverter.toPilgrimageDetailDto(pilgrimage, Long.valueOf(visitedPilgrimages.size()));
+        Long visitedPilgrimages = visitedPilgrimageRepository
+                .findByDistinctCount(member.getId(), pilgrimage.getRally().getId());
+        PilgrimageDto.PilgrimageDetailDto result = PilgrimageConverter.toPilgrimageDetailDto(pilgrimage, visitedPilgrimages);
 
         // 이 성지순례에 인증 기록이 있다면 isWritable -> true
         List<VisitedPilgrimage> visitedLog = visitedPilgrimageRepository
@@ -197,9 +197,9 @@ public class PilgrimageQueryService {
         if (member == null) {
             return RallyConverter.toRallyTrendingDto(rallys.get(0),0L);
         }
-        List<VisitedPilgrimage> visited = visitedPilgrimageRepository
-                .findDistinctByMemberAndPilgrimage_Rally(member, rallys.get(0));
-        return RallyConverter.toRallyTrendingDto(rallys.get(0), Long.valueOf(visited.size()));
+        Long visited = visitedPilgrimageRepository
+                .findByDistinctCount(member.getId(), rallys.get(0).getId());
+        return RallyConverter.toRallyTrendingDto(rallys.get(0), visited);
     }
 
     /***
@@ -216,8 +216,8 @@ public class PilgrimageQueryService {
                     .collect(Collectors.toList());
         }
         return rallyList.stream().map(rally->{
-            List<VisitedPilgrimage> visitedPilgrimages = visitedPilgrimageRepository.findDistinctByMemberAndPilgrimage_Rally(member, rally);
-            return RallyConverter.toPilgrimageCategoryAnimeDto(rally, Long.valueOf(visitedPilgrimages.size()));
+            Long visitedPilgrimages = visitedPilgrimageRepository.findByDistinctCount(member.getId(), rally.getId());
+            return RallyConverter.toPilgrimageCategoryAnimeDto(rally, visitedPilgrimages);
         }).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/favoriteplace/global/exception/ErrorCode.java
+++ b/src/main/java/com/favoriteplace/global/exception/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
 
     //Pilgrimage (3000번대)
     PILGRIMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, 3001, "성지순례 정보를 찾을 수 없습니다."),
+    PILGRIMAGE_ALREADY_CERTIFIED(HttpStatus.BAD_REQUEST, 3002, "인증 후 24시간이 지나야 재인증할 수 있습니다."),
+    PILGRIMAGE_CAN_NOT_CERTIFIED(HttpStatus.BAD_REQUEST, 3003, "인증 장소와 현재 위치의 거리가 너무 멉니다."),
 
     //Rally (4000번대)
     RALLY_NOT_FOUND(HttpStatus.BAD_REQUEST, 4001, "랠리 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
### 작업내역
- 랠리 찜하기 api 개발
- 성지순례 방문 인증 api 개발
- 조회 기능 중 방문 중복 확인 안되는 api 수정
- 성지순례 상세 조회 dto 인증하기 버튼 활성화 여부 추가
- CompleteRally 도메인 추가
- 성지순례 랠리 더미데이터 추가 (위도, 이미지 없는 버전)