### PR TITLE
[FIX #42] 일반 회원가입 - 사용자 프로필 이미지 + 새싹회원 칭호 저장

### DIFF
--- a/src/main/java/com/favoriteplace/InitDB.java
+++ b/src/main/java/com/favoriteplace/InitDB.java
@@ -13,29 +13,33 @@ import com.favoriteplace.app.domain.travel.Rally;
 import com.favoriteplace.app.repository.AddressRepository;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
+import jdk.jfr.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class InitDB {
-//    private final InitService initService;
-//
-//    @PostConstruct
-//    public void init(){
-////        initService.createMember("1");
-//        initService.initRallyAndPilgrimage();
-//        initService.initDB();
-//    }
-//
-//    @Component
-//    @RequiredArgsConstructor
-//    @Transactional
-//    static class InitService {
-//        private final EntityManager em;
-//        private final AddressRepository addressRepository;
-//
+    private final InitService initService;
+
+    @PostConstruct
+    public void init(){
+        initService.initAddress();
+        initService.initWeatheringWithYou();
+        initService.initOshiNoKo();
+        initService.initJujutsuKaisen();
+    }
+
+    @Component
+    @RequiredArgsConstructor
+    @Transactional
+    static class InitService {
+        private final EntityManager em;
+        private final AddressRepository addressRepository;
+
 //        public void initDB(){
 //            Image image1 = Image.builder()
 //                    .post(null).guestBook(null)
@@ -49,8 +53,7 @@ public class InitDB {
 //                    .image(image1).name("icon1")
 //                    .status(SaleStatus.NOT_FOR_SALE).type(ItemType.ICON)
 //                    .saleDeadline(null).point(10L).category(ItemCategory.NEW)
-//                    .saleDeadline(null).point(null)
-//                    .description(null).build();
+//                    .saleDeadline(null).description(null).build();
 //            Item item2 = Item.builder()
 //                    .image(image2).name("title1")
 //                    .status(SaleStatus.NOT_FOR_SALE).type(ItemType.TITLE)
@@ -104,14 +107,14 @@ public class InitDB {
 //            Address address2 = Address.builder().state("도쿄도").district("시부야구").build();
 //            em.persist(address2);
 //
-//            Rally rally1 = Rally.builder().id(0L)
+//            Rally rally1 = Rally.builder()
 //                    .item(item1).image(image1).name("최애의 아이")
 //                    .description("환생한 내가 아이돌의 자녀??!!").achieveNumber(10L)
-//                    .pilgrimageNumber(4L).build();
-//            Rally rally2 = Rally.builder().id(1L)
+//                    .pilgrimageNumber(1L).build();
+//            Rally rally2 = Rally.builder()
 //                    .item(item2).image(image2).name("날씨의 아이")
 //                    .description("비야 멈춰라!").achieveNumber(20L)
-//                    .pilgrimageNumber(2L).build();
+//                    .pilgrimageNumber(5L).build();
 //            em.merge(rally1); em.merge(rally2);
 //
 //            Pilgrimage pilgrimage1 = Pilgrimage.builder()
@@ -166,114 +169,145 @@ public class InitDB {
 //                    .member(member).post(post1).guestBook(null).content("P댓글6").build();
 //            em.merge(comment1); em.merge(comment2);em.merge(comment3);em.merge(comment4);em.merge(comment5);em.merge(comment6);
 //        }
-//
-//        public void initMember(){
-//            createMember("1");
-//        }
-//
-//        public void initRallyAndPilgrimage(){
-//            Address addressSibuya = createAddress("도쿄도", "시부야구");
-//            Address addressShinjuku = createAddress("도쿄도", "신주쿠구");
-//            Address addressMinato = createAddress("도쿄도", "미나토구");
-//            Rally rally = createRally("날씨의 아이", "천비가 멈추지 않던 여름날, 고향을 떠나 도쿄로 온 가출 소년 호다카는 우연히 비를 멈추게 하는 능력을 가진 신비한 소녀 히나를 만난다. 히나의 능력을 알게 된 호다카는 그 능력을 사용해 돈을 벌 계획을 세운다. 매일 내리는 비로 우울해하는 도쿄 사람들은 히나의 능력으로 인해 행복감을 되찾게 되지만, 호다카와 히나는 뜻밖의 비밀을 마주하게 된다.");
-//            Pilgrimage pilgrimage1 = createPilgrimage(addressSibuya, rally, "시부야 스크램블교차로");
-//            Pilgrimage pilgrimage2 = createPilgrimage(addressMinato, rally, "롯폰기 힐즈 스카이덱 전망대");
-//            Pilgrimage pilgrimage3 = createPilgrimage(addressMinato, rally, "오다이바 해변공원");
-//            Pilgrimage pilgrimage4 = createPilgrimage(addressShinjuku, rally, "맥도날드 신주쿠 역전점");
-//        }
-//
-//        public Member createMember(String number){
-//            Image image1 = createImage("imgIcon"+number);
-//            Image image2 = createImage("imgTitle"+number);
-//
-//            Item item1 = createItem(image1, "icon"+number, ItemType.ICON);
-//            Item item2 = createItem(image2, "title"+number, ItemType.TITLE);
-//
-//            Member member = Member.builder()
-//                    .id(0L)
-//                    .profileIcon(item1)
-//                    .profileTitle(item2)
-//                    .email("user@naver.com")
-//                    .password("1234")
-//                    .birthday(null)
-//                    .nickname("user"+number)
-//                    .description("hi")
-//                    .profileImageUrl("")
-//                    .status(MemberStatus.Y)
-//                    .alarmAllowance(false)
-//                    .point(0L)
-//                    .loginType(LoginType.SELF)
-//                    .refreshToken("")
-//                    .build();
-//            em.merge(member);
-//            return member;
-//        }
-//
-//        public Rally createRally(String name, String description){
-//            Image image1 = createImage("rallyItemImg");
-//            Image animeImg = createImage("animeImg");
-//            Item item1 = createItem(image1, "rallyTitle", ItemType.TITLE);
-//            Rally rally = Rally.builder()
-//                    .item(item1)
-//                    .image(animeImg)
-//                    .name(name)
-//                    .description(description)
-//                    .achieveNumber(0L)
-//                    .pilgrimageNumber(0L)
-//                    .build();
-//            em.persist(rally);
-//            return rally;
-//        }
-//
-//        public Pilgrimage createPilgrimage(Address address, Rally rally, String detailAddress){
-//            Image realImg = createImage(rally.getName()+"PilRealImg");
-//            Image animeImg = createImage(rally.getName()+"PilAnimeImg");
-//            Pilgrimage pilgrimage = Pilgrimage.builder()
-//                    .address(address)
-//                    .rally(rally)
-//                    .virtualImage(animeImg)
-//                    .realImage(realImg)
-//                    .rallyName(rally.getName())
-//                    .detailAddress(detailAddress)
-//                    .latitude(0.0)
-//                    .longitude(0.0)
-//                    .build();
-//            rally.addPilgrimage();
-//            em.merge(rally);
-//            em.persist(pilgrimage);
-//            return pilgrimage;
-//        }
-//
-//        public Address createAddress(String state, String district){
-//            Address address = Address.builder()
-//                    .state(state)
-//                    .district(district)
-//                    .build();
-//            em.persist(address);
-//            return address;
-//        }
-//        private Item createItem(Image image1, String name, ItemType type) {
-//            Item item = Item.builder()
-//                    .image(image1)
-//                    .name(name)
-//                    .status(SaleStatus.NOT_FOR_SALE)
-//                    .type(type)
-//                    .saleDeadline(null)
-//                    .point(null)
-//                    .description(null)
-//                    .build();
-//            em.persist(item);
-//            return item;
-//        }
-//        private Image createImage(String url) {
-//            Image image1 = Image.builder()
-//                    .post(null)
-//                    .guestBook(null)
-//                    .url(url)
-//                    .build();
-//            em.persist(image1);
-//            return image1;
-//        }
-//
-//    }
+
+        public void initMember(){
+            createMember("1");
+        }
+
+        public void initAddress(){
+            Address addressSibuya = createAddress("도쿄도", "시부야구");
+            Address addressShinjuku = createAddress("도쿄도", "신주쿠구");
+            Address addressMinato = createAddress("도쿄도", "미나토구");
+        }
+
+        public void initWeatheringWithYou(){
+            Address addressSibuya = addressRepository.findById(1L).orElse(null);
+            Address addressShinjuku = addressRepository.findById(2L).orElse(null);
+            Address addressMinato = addressRepository.findById(3L).orElse(null);
+
+            Rally rally = createRally("날씨의 아이", "천비가 멈추지 않던 여름날, 고향을 떠나 도쿄로 온 가출 소년 호다카는 우연히 비를 멈추게 하는 능력을 가진 신비한 소녀 히나를 만난다. 히나의 능력을 알게 된 호다카는 그 능력을 사용해 돈을 벌 계획을 세운다. 매일 내리는 비로 우울해하는 도쿄 사람들은 히나의 능력으로 인해 행복감을 되찾게 되지만, 호다카와 히나는 뜻밖의 비밀을 마주하게 된다.");
+            Pilgrimage pilgrimage1 = createPilgrimage(addressShinjuku, rally, "맥도날드 세이부 신주쿠역 앞점");
+            Pilgrimage pilgrimage2 = createPilgrimage(addressShinjuku, rally, "아타미 빌딩");
+            Pilgrimage pilgrimage3 = createPilgrimage(addressSibuya, rally, "시부야 스크램블 교차로");
+            Pilgrimage pilgrimage4 = createPilgrimage(addressMinato, rally, "시바 공원");
+        }
+
+        public void initOshiNoKo(){
+            Address addressSibuya = addressRepository.findById(1L).orElse(null);
+            Address addressShinjuku = addressRepository.findById(2L).orElse(null);
+            Rally rally = createRally("최애의 아이", "‘최애의 아이’는 주인공인 호시노 루비, 호시노 아쿠아를 비롯한 연예계 친구들이 다니고 있는 학교나 사무실의 위치, 자주 등장하는 배경 등을 미루어보았을 때 도쿄도, 특히 메구로구 중심으로 배경지가 설정되어 있음을 알 수 있다. 특히 ‘오늘은 달콤하게’ 촬영 장면의 배경이 된 오다이바와 도쿄 돔, 무도관 등을 제외하면 메구로-신주쿠-시부야구의 도쿄 서쪽이 대부분이므로 한 번에 여러 장소를 둘러보기 좋다.");
+            Pilgrimage pilgrimage1 = createPilgrimage(addressSibuya, rally, "에비스 가든 플레이스");
+            Pilgrimage pilgrimage2 = createPilgrimage(addressSibuya, rally, "패밀리 마트 시부야 공원 도오리점");
+            Pilgrimage pilgrimage3 = createPilgrimage(addressSibuya, rally, "에비스 미나미 2공원");
+            Pilgrimage pilgrimage4 = createPilgrimage(addressSibuya, rally, "스타벅스 시부야 츠타야점");
+            Pilgrimage pilgrimage5 = createPilgrimage(addressShinjuku, rally, "쿠시카츠 타나카 신주쿠산초메점");
+        }
+
+        public void initJujutsuKaisen(){
+            Address addressSibuya = addressRepository.findById(1L).orElse(null);
+            Address addressShinjuku = addressRepository.findById(2L).orElse(null);
+            Address addressMinato = addressRepository.findById(3L).orElse(null);
+            Rally rally = createRally("주술회전", "‘주술고전’이 도쿄와 교토에 하나씩 있는 만큼, 1기는 도쿄도와 교토부를 배경으로 하는 장면이 많다. 1기 오프닝의 배경 역시 도쿄 스카이트리, 신주쿠의 눈 등 다양한 도쿄의 장소를 담아내기도 하였다. 2기는 부제목이 ‘시부야 사변’인 만큼 도쿄도 시부야구를 배경으로 스토리가 진행되었기에 시부야의 실제 장소가 여럿 등장한다.");
+            Pilgrimage pilgrimage1 = createPilgrimage(addressShinjuku, rally, "KFC 니시신주쿠점 건너편");
+            Pilgrimage pilgrimage2 = createPilgrimage(addressSibuya, rally, "시부야 히카리에 입구");
+            Pilgrimage pilgrimage3 = createPilgrimage(addressMinato, rally, "롯폰기 힐즈 아레나");
+            Pilgrimage pilgrimage4 = createPilgrimage(addressMinato, rally, "도쿄 스카이트리");
+            Pilgrimage pilgrimage5 = createPilgrimage(addressMinato, rally, "신주쿠의 눈");
+        }
+
+        public Member createMember(String number){
+            Image image1 = createImage("imgIcon"+number);
+            Image image2 = createImage("imgTitle"+number);
+
+            Item item1 = createItem(image1, "icon"+number, ItemType.ICON, ItemCategory.NEW);
+            Item item2 = createItem(image2, "title"+number, ItemType.TITLE, ItemCategory.NEW);
+
+            Member member = Member.builder()
+                .id(0L)
+                .profileIcon(item1)
+                .profileTitle(item2)
+                .email("user@naver.com")
+                .password("1234")
+                .birthday(null)
+                .nickname("user"+number)
+                .description("hi")
+                .profileImageUrl("")
+                .status(MemberStatus.Y)
+                .alarmAllowance(false)
+                .point(0L)
+                .loginType(LoginType.SELF)
+                .refreshToken("")
+                .build();
+            em.merge(member);
+            return member;
+        }
+
+        public Rally createRally(String name, String description){
+            Image image1 = createImage("rallyItemImg");
+            Image animeImg = createImage("animeImg");
+            Item item1 = createItem(image1, "rallyTitle", ItemType.TITLE, ItemCategory.NEW);
+            Rally rally = Rally.builder()
+                .item(item1)
+                .image(animeImg)
+                .name(name)
+                .description(description)
+                .achieveNumber(0L)
+                .pilgrimageNumber(0L)
+                .build();
+            em.persist(rally);
+            return rally;
+        }
+
+        public Pilgrimage createPilgrimage(Address address, Rally rally, String detailAddress){
+            Image realImg = createImage(rally.getName()+"PilRealImg");
+            Image animeImg = createImage(rally.getName()+"PilAnimeImg");
+            Pilgrimage pilgrimage = Pilgrimage.builder()
+                .address(address)
+                .rally(rally)
+                .virtualImage(animeImg)
+                .realImage(realImg)
+                .rallyName(rally.getName())
+                .detailAddress(detailAddress)
+                .latitude(0.0)
+                .longitude(0.0)
+                .build();
+            rally.addPilgrimage();
+            em.merge(rally);
+            em.persist(pilgrimage);
+            return pilgrimage;
+        }
+
+        public Address createAddress(String state, String district){
+            Address address = Address.builder()
+                .state(state)
+                .district(district)
+                .build();
+            em.persist(address);
+            return address;
+        }
+        private Item createItem(Image image1, String name, ItemType type, ItemCategory itemCategory) {
+            Item item = Item.builder()
+                .image(image1)
+                .name(name)
+                .status(SaleStatus.NOT_FOR_SALE)
+                .type(type)
+                .saleDeadline(null)
+                .point(0L)
+                .description("item 설명")
+                .category(itemCategory)
+                .build();
+            em.persist(item);
+            return item;
+        }
+        private Image createImage(String url) {
+            Image image1 = Image.builder()
+                .post(null)
+                .guestBook(null)
+                .url(url)
+                .build();
+            em.persist(image1);
+            return image1;
+        }
+
+    }
 }

--- a/src/main/java/com/favoriteplace/app/controller/MemberController.java
+++ b/src/main/java/com/favoriteplace/app/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.favoriteplace.app.dto.member.MemberDto;
 import com.favoriteplace.app.dto.member.MemberDto.EmailCheckReqDto;
 import com.favoriteplace.app.dto.member.MemberDto.EmailDuplicateResDto;
 import com.favoriteplace.app.dto.member.MemberDto.EmailSendResDto;
+import com.favoriteplace.app.dto.member.MemberDto.MemberDetailResDto;
 import com.favoriteplace.app.dto.member.MemberDto.MemberSignUpReqDto;
 import com.favoriteplace.app.dto.member.MemberDto.TokenInfo;
 import com.favoriteplace.app.service.MailSendService;
@@ -12,6 +13,7 @@ import com.favoriteplace.global.security.provider.JwtTokenProvider;
 import com.favoriteplace.global.util.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,9 +35,9 @@ public class MemberController {
     private final SecurityUtil securityUtil;
 
     @PostMapping("/signup")
-    public ResponseEntity<TokenInfo> signup(@RequestPart(required = false) List<MultipartFile> images, @RequestPart
-        MemberSignUpReqDto data) {
-        return ResponseEntity.ok(memberService.signup(data));
+    public ResponseEntity<MemberDetailResDto> signup(@RequestPart(required = false) List<MultipartFile> images, @RequestPart
+        MemberSignUpReqDto data) throws IOException {
+        return ResponseEntity.ok(memberService.signup(data, images));
     }
 
     @PostMapping("/signup/email")

--- a/src/main/java/com/favoriteplace/app/domain/Member.java
+++ b/src/main/java/com/favoriteplace/app/domain/Member.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,11 +34,11 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "profile_title_id")
     private Item profileTitle;
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "profile_icon_id")
     private Item profileIcon;
 

--- a/src/main/java/com/favoriteplace/app/dto/member/MemberDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/member/MemberDto.java
@@ -3,6 +3,8 @@ package com.favoriteplace.app.dto.member;
 import com.favoriteplace.app.domain.Member;
 import com.favoriteplace.app.domain.enums.LoginType;
 import com.favoriteplace.app.domain.enums.MemberStatus;
+import com.favoriteplace.app.domain.item.Item;
+import com.favoriteplace.global.gcpImage.ConvertUuidToUrl;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -24,17 +26,37 @@ public class MemberDto {
         public Boolean snsAllow;
         public String introduction;
 
-        public Member toEntity(String encodedPassword, String profileImg) {
+        public Member toEntity(String encodedPassword, String profileImg, Item titleItem) {
             return Member.builder()
                 .nickname(nickname)
                 .email(email)
                 .password(encodedPassword)
                 .alarmAllowance(snsAllow)
                 .description(introduction)
-                .profileImageUrl(profileImg)
+                .profileImageUrl(profileImg == null ? null : ConvertUuidToUrl.convertUuidToUrl(profileImg))
                 .point(0L)
                 .loginType(LoginType.SELF)
+                .profileTitle(titleItem)
                 .status(MemberStatus.Y)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class MemberDetailResDto {
+        private String nickname;
+        private String introduction;
+        private String profileImage;
+        private String profileTitleItem;
+
+        public static MemberDetailResDto from(Member member) {
+            return MemberDetailResDto.builder()
+                .nickname(member.getNickname())
+                .introduction(member.getDescription())
+                .profileImage(member.getProfileImageUrl())
+                .profileTitleItem(member.getProfileTitle().getImage().getUrl())
                 .build();
         }
     }

--- a/src/main/java/com/favoriteplace/app/repository/ItemRepository.java
+++ b/src/main/java/com/favoriteplace/app/repository/ItemRepository.java
@@ -23,4 +23,6 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("SELECT it from Item it join fetch it.image im where it.id = :item_id")
     Optional<Item> findAllByIdWithImage(@Param("item_id") Long itemID);
 
+    Optional<Item> findByName(String name);
+
 }

--- a/src/main/java/com/favoriteplace/app/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/service/MemberService.java
@@ -5,25 +5,32 @@ import static com.favoriteplace.global.exception.ErrorCode.USER_ALREADY_EXISTS;
 import com.favoriteplace.app.domain.Member;
 import com.favoriteplace.app.domain.community.GuestBook;
 import com.favoriteplace.app.domain.community.Post;
+import com.favoriteplace.app.domain.item.Item;
 import com.favoriteplace.app.dto.UserInfoResponseDto;
 import com.favoriteplace.app.dto.member.MemberDto;
 import com.favoriteplace.app.dto.member.MemberDto.EmailCheckReqDto;
 import com.favoriteplace.app.dto.member.MemberDto.EmailDuplicateResDto;
 import com.favoriteplace.app.dto.member.MemberDto.EmailSendReqDto;
+import com.favoriteplace.app.dto.member.MemberDto.MemberDetailResDto;
 import com.favoriteplace.app.dto.member.MemberDto.MemberSignUpReqDto;
 import com.favoriteplace.app.repository.GuestBookRepository;
+import com.favoriteplace.app.repository.ItemRepository;
 import com.favoriteplace.app.repository.MemberRepository;
 import com.favoriteplace.app.repository.PostRepository;
 import com.favoriteplace.global.exception.ErrorCode;
 import com.favoriteplace.global.exception.RestApiException;
+import com.favoriteplace.global.gcpImage.UploadImage;
 import com.favoriteplace.global.util.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional(readOnly = true)
@@ -35,15 +42,26 @@ public class MemberService {
     private final GuestBookRepository guestBookRepository;
     private final PasswordEncoder passwordEncoder;
     public final SecurityUtil securityUtil;
+    private final UploadImage uploadImage;
+    private final ItemRepository itemRepository;
 
     @Transactional
-    public MemberDto.TokenInfo signup(MemberSignUpReqDto memberSignUpReqDto) {
+    public MemberDto.MemberDetailResDto signup(MemberSignUpReqDto memberSignUpReqDto, List<MultipartFile> images)
+        throws IOException {
+        String uuid = null;
         String password = passwordEncoder.encode(memberSignUpReqDto.getPassword());
-        Member member = memberSignUpReqDto.toEntity(password, null);
 
-        //TODO 유저 프로필 이미지 + 새싹회원 칭호 저장
+        if(!(images == null)) {
+            uuid = uploadImage.uploadImageToCloud(images.get(0));
+        }
+
+        Item titleItem = itemRepository.findByName("새싹회원").get();
+
+        Member member = memberSignUpReqDto.toEntity(password, uuid, titleItem);
+
         memberRepository.save(member);
-        return null;
+
+        return MemberDetailResDto.from(member);
     }
 
     @Transactional

--- a/src/main/java/com/favoriteplace/app/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/service/MemberService.java
@@ -58,7 +58,6 @@ public class MemberService {
         Item titleItem = itemRepository.findByName("새싹회원").get();
 
         Member member = memberSignUpReqDto.toEntity(password, uuid, titleItem);
-
         memberRepository.save(member);
 
         return MemberDetailResDto.from(member);

--- a/src/main/java/com/favoriteplace/app/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/service/MemberService.java
@@ -48,6 +48,16 @@ public class MemberService {
     @Transactional
     public MemberDto.MemberDetailResDto signup(MemberSignUpReqDto memberSignUpReqDto, List<MultipartFile> images)
         throws IOException {
+        memberRepository.findByEmail(memberSignUpReqDto.getEmail())
+            .ifPresentOrElse(
+                existingMember -> {
+                    throw new RestApiException(USER_ALREADY_EXISTS);
+                },
+                () -> {
+                    // 값이 없을 때 수행할 동작 (예외를 발생시키지 않는 경우)
+                }
+            );
+
         String uuid = null;
         String password = passwordEncoder.encode(memberSignUpReqDto.getPassword());
 

--- a/src/main/java/com/favoriteplace/app/service/PilgrimageQueryService.java
+++ b/src/main/java/com/favoriteplace/app/service/PilgrimageQueryService.java
@@ -74,6 +74,7 @@ public class PilgrimageQueryService {
 
         // 주소, 성지순례 리스트 정보 담은 주소 리스트 생성
         List<Address> addressList = addressRepository.findByPilgrimages_Rally(rally);
+        System.out.println(addressList.size());
         if (addressList.isEmpty()) throw new RestApiException(ErrorCode.PILGRIMAGE_NOT_FOUND);
 
         List<RallyDto.RallyAddressDto> addressDtoList = addressList.stream()


### PR DESCRIPTION
`추가사항`

> 최종 회원가입 전에 중복검사를 거치는 과정이 따로 있어서 이메일 중복 검사를 따로 진행하지 않았지만, 테스트 시에 동일한 이메일을 가진 유저가 중복해서 생기는 것을 방지하기 위해 예외처리 추가