### PR TITLE
[FIX/#116] 일반 회원가입시 ATK, RTK 함께 반환하도록 수정 & JwtAuthenticationFilter 클래스 주석처리 해제

### DIFF
--- a/src/main/java/com/favoriteplace/app/dto/member/MemberDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/member/MemberDto.java
@@ -50,13 +50,17 @@ public class MemberDto {
         private String introduction;
         private String profileImage;
         private String profileTitleItem;
+        private String accessToken;
+        private String refreshToken;
 
-        public static MemberDetailResDto from(Member member) {
+        public static MemberDetailResDto from(Member member, TokenInfo tokenInfo) {
             return MemberDetailResDto.builder()
                 .nickname(member.getNickname())
                 .introduction(member.getDescription())
                 .profileImage(member.getProfileImageUrl())
                 .profileTitleItem(member.getProfileTitle().getDefaultImage().getUrl())
+                .accessToken(tokenInfo.accessToken)
+                .refreshToken(tokenInfo.refreshToken)
                 .build();
         }
     }

--- a/src/main/java/com/favoriteplace/app/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/service/MemberService.java
@@ -69,7 +69,10 @@ public class MemberService {
         Member member = memberSignUpReqDto.toEntity(password, uuid, titleItem);
         memberRepository.save(member);
 
-        return MemberDetailResDto.from(member);
+        MemberDto.TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getEmail());
+        member.updateRefreshToken(tokenInfo.getRefreshToken());
+
+        return MemberDetailResDto.from(member, tokenInfo);
     }
 
     @Transactional

--- a/src/main/java/com/favoriteplace/global/security/Filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/favoriteplace/global/security/Filter/JwtAuthenticationFilter.java
@@ -59,14 +59,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // Add more paths and methods as needed
     );
 
-//    @Override
-//    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-//        String requestURI = request.getServletPath();
-//        String method = request.getMethod();
-//
-//        return !excludePaths.stream()
-//            .anyMatch(excludePath -> excludePath.matches(requestURI, method));
-//    }
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getServletPath();
+        String method = request.getMethod();
+
+        return !excludePaths.stream()
+            .anyMatch(excludePath -> excludePath.matches(requestURI, method));
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/src/main/java/com/favoriteplace/global/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/favoriteplace/global/security/handler/CustomAuthenticationSuccessHandler.java
@@ -44,7 +44,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
         //인증 정보를 기반으로 JWT 토큰 생성
         response.setContentType(APPLICATION_JSON_VALUE);
-        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+        TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getEmail());
 
         //refreshToken 업데이트
         member.updateRefreshToken(tokenInfo.getRefreshToken());

--- a/src/main/java/com/favoriteplace/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/favoriteplace/global/security/provider/JwtTokenProvider.java
@@ -29,8 +29,8 @@ public class JwtTokenProvider {
     private final Long refreshExpirePeriod = 24 * 60 * 60 * 1000L * 40;
     private final UserDetailsService userDetailsService;
 
-    public TokenInfo generateToken(Authentication authentication) {
-        Claims claims = Jwts.claims().setSubject(authentication.getName());
+    public TokenInfo generateToken(String userEmail) {
+        Claims claims = Jwts.claims().setSubject(userEmail);
         Date now = new Date();
 
         // Access Token 생성
@@ -42,7 +42,7 @@ public class JwtTokenProvider {
             .compact();
 
         // Refresh Token 생성
-        String refreshToken = createRefreshToken(authentication);
+        String refreshToken = createRefreshToken(userEmail);
         return TokenInfo.builder()
             .grantType("Bearer")
             .accessToken(accessToken)
@@ -50,8 +50,8 @@ public class JwtTokenProvider {
             .build();
     }
 
-    public String createRefreshToken(Authentication authentication){
-        Claims claims = Jwts.claims().setSubject(authentication.getName());
+    public String createRefreshToken(String userEmail){
+        Claims claims = Jwts.claims().setSubject(userEmail);
         Date now = new Date();
 
         String refreshToken = Jwts.builder()


### PR DESCRIPTION
# 📄 Work Description
- 일반 회원가입시 ATK, RTK를 같이 반환핟록 수정하였습니다.

# ⚙️ ISSUE
- closed #116 


# 📷 Screenshot
<img width="1289" alt="스크린샷 2024-08-14 오전 11 25 06" src="https://github.com/user-attachments/assets/6d6b7468-6d2e-478c-93bc-615e2147455a">


# 💬 To Reviewers
1. 일반 회원가입시에 바로 ATK, RTK를 주지 않아서 회원가입 후 로그인을 거쳐야하는 번거로움이 있어서 해당 로직을 수정했습니다!
Authentication을 기반으로 토큰을 생성했었는데, 사용자 email(고유한 값)으로 토큰을 생성하도록 로직을 수정했습니다!
이유는 충분히 사용자 email을 기반으로 고유한 토큰을 만들어 낼 수 있는데 Authentication을 만들면서 리소스를 쓸 필요가 없다 판단하였습니다!
https://github.com/UMC5th-bias/Server/blob/69e9340b9551f4adac1b8660d1456697821f3021/src/main/java/com/favoriteplace/global/security/provider/JwtTokenProvider.java#L32-L51

<br/>
2. JwtAuthenticationFilter 클래스 shouldNotFilter 주석처리 해제를 해제했습니다!
해당코드가 주석처리가 되어있지 않아야 인증이 필요없는 API의 경우 필터를 통과하지 않게 되는데, 주석처리가 되어있어서 해제하였습니다!

https://github.com/UMC5th-bias/Server/blob/69e9340b9551f4adac1b8660d1456697821f3021/src/main/java/com/favoriteplace/global/security/Filter/JwtAuthenticationFilter.java#L62-L69


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
