### PR TITLE
[FEAT] FeignClient를 사용한 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	//FeignClient
-	implementation "org.springframework.cloud:spring-cloud-starter-openfeign:3.1.0"
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.4'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
 	//email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 //	implementation 'com.sun.mail:javax.mail:1.6.2' // 또는 최신 버전
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
@@ -49,9 +50,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	//FeignClient
+	implementation "org.springframework.cloud:spring-cloud-starter-openfeign:3.1.0"
+
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-
 
 	//image
 	implementation 'com.google.cloud:google-cloud-storage:2.20.1'

--- a/src/main/java/com/favoriteplace/FavoritePlaceApplication.java
+++ b/src/main/java/com/favoriteplace/FavoritePlaceApplication.java
@@ -2,6 +2,7 @@ package com.favoriteplace;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -10,6 +11,7 @@ import java.util.TimeZone;
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableFeignClients
 public class FavoritePlaceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/favoriteplace/app/controller/MemberController.java
+++ b/src/main/java/com/favoriteplace/app/controller/MemberController.java
@@ -30,10 +30,10 @@ public class MemberController {
     private final SecurityUtil securityUtil;
 
     @PostMapping("/login/kakao")
-    public ResponseEntity<Void> kakaoLogin(
+    public ResponseEntity<TokenInfo> kakaoLogin(
             @RequestHeader("Authorization") final String token
     ) {
-        memberService.kakoLogin(token);
+        return ResponseEntity.ok(memberService.kakaoLogin(token));
     }
 
     @PostMapping("/signup")

--- a/src/main/java/com/favoriteplace/app/controller/MemberController.java
+++ b/src/main/java/com/favoriteplace/app/controller/MemberController.java
@@ -17,13 +17,7 @@ import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -35,9 +29,17 @@ public class MemberController {
     private final JwtTokenProvider jwtTokenProvider;
     private final SecurityUtil securityUtil;
 
+    @PostMapping("/login/kakao")
+    public ResponseEntity<Void> kakaoLogin(
+            @RequestHeader("Authorization") final String token
+    ) {
+        memberService.kakoLogin(token);
+    }
+
     @PostMapping("/signup")
-    public ResponseEntity<MemberDetailResDto> signup(@RequestPart(required = false) List<MultipartFile> images, @RequestPart
-        MemberSignUpReqDto data) throws IOException {
+    public ResponseEntity<MemberDetailResDto> signup(
+            @RequestPart(required = false) List<MultipartFile> images,
+            @RequestPart MemberSignUpReqDto data) throws IOException {
         return ResponseEntity.ok(memberService.signup(data, images));
     }
 

--- a/src/main/java/com/favoriteplace/app/domain/Member.java
+++ b/src/main/java/com/favoriteplace/app/domain/Member.java
@@ -72,6 +72,8 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private LoginType loginType;
 
+    private Long authId;
+
     private String refreshToken;
 
     public void updatePassword(String password) { this.password = password; }

--- a/src/main/java/com/favoriteplace/app/dto/member/AuthKakaoLoginDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/member/AuthKakaoLoginDto.java
@@ -1,0 +1,15 @@
+package com.favoriteplace.app.dto.member;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AuthKakaoLoginDto(
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+
+) {
+    public record KakaoAccount(
+            String email
+    ) {
+
+    }
+}

--- a/src/main/java/com/favoriteplace/app/dto/member/MemberDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/member/MemberDto.java
@@ -50,13 +50,17 @@ public class MemberDto {
         private String introduction;
         private String profileImage;
         private String profileTitleItem;
+        private String accessToken;
+        private String refreshToken;
 
-        public static MemberDetailResDto from(Member member) {
+        public static MemberDetailResDto from(Member member, TokenInfo tokenInfo) {
             return MemberDetailResDto.builder()
                 .nickname(member.getNickname())
                 .introduction(member.getDescription())
                 .profileImage(member.getProfileImageUrl())
                 .profileTitleItem(member.getProfileTitle().getDefaultImage().getUrl())
+                .accessToken(tokenInfo.accessToken)
+                .refreshToken(tokenInfo.refreshToken)
                 .build();
         }
     }

--- a/src/main/java/com/favoriteplace/app/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/service/MemberService.java
@@ -69,7 +69,10 @@ public class MemberService {
         Member member = memberSignUpReqDto.toEntity(password, uuid, titleItem);
         memberRepository.save(member);
 
-        return MemberDetailResDto.from(member);
+        MemberDto.TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getEmail());
+        member.updateRefreshToken(tokenInfo.getRefreshToken());
+
+        return MemberDetailResDto.from(member, tokenInfo);
     }
 
     @Transactional

--- a/src/main/java/com/favoriteplace/app/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/service/MemberService.java
@@ -44,6 +44,11 @@ public class MemberService {
     private final ItemRepository itemRepository;
     private final RedisTemplate redisTemplate;
 
+    public void kakoLogin(final String token) {
+
+
+    }
+
     @Transactional
     public MemberDto.MemberDetailResDto signup(MemberSignUpReqDto memberSignUpReqDto, List<MultipartFile> images)
         throws IOException {
@@ -108,8 +113,7 @@ public class MemberService {
         }
 
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-        Member member = memberRepository.findByEmail(authentication.getName())
-            .orElseThrow(() -> new RestApiException(USER_NOT_FOUND));
+        Member member = findMember(authentication.getName());
 
         if(member.getRefreshToken() != null && !member.getRefreshToken().isEmpty()) {
             member.deleteRefreshToken(member.getRefreshToken());
@@ -119,6 +123,11 @@ public class MemberService {
         Long expriation = jwtTokenProvider.getExpiration(accessToken);
         redisTemplate.opsForValue()
             .set(accessToken, "logout", expriation, TimeUnit.MICROSECONDS);
+    }
+
+    public Member findMember(final String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RestApiException(USER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/favoriteplace/global/exception/ErrorCode.java
+++ b/src/main/java/com/favoriteplace/global/exception/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     USER_NOT_AUTHOR(HttpStatus.FORBIDDEN, 2005, "해당 게시글의 작성자가 아닙니다."),
     CANT_BLOCK_SELF(HttpStatus.FORBIDDEN, 2006, "스스로를 차단할 수 없습니다."),
     TOKEN_NOT_VALID(HttpStatus.BAD_REQUEST, 2007, "not valid token"),
+    NOT_SIGNUP_WITH_KAKAO(HttpStatus.BAD_REQUEST, 2008, "해당 계정으로 회원가입한 이력이 없습니다. 카카오 회원가입 필요."),
+
 
     //Pilgrimage (3000번대)
     PILGRIMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, 3001, "성지순례 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/favoriteplace/global/exception/ErrorCode.java
+++ b/src/main/java/com/favoriteplace/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     /**
      * 에러코드 자유롭게 추가
      */
+    NOT_FOUND(HttpStatus.NOT_FOUND,404, "요청한 리소스를 찾을 수 없습니다."),
     INVALID_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 파라미터입니다."),
     INVALID_FORMAT_ERROR(HttpStatus.BAD_REQUEST,400, "올바르지 않은 포맷입니다."),
     INVALID_TYPE_ERROR(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 타입입니다."),

--- a/src/main/java/com/favoriteplace/global/security/Filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/favoriteplace/global/security/Filter/JwtAuthenticationFilter.java
@@ -59,14 +59,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // Add more paths and methods as needed
     );
 
-//    @Override
-//    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-//        String requestURI = request.getServletPath();
-//        String method = request.getMethod();
-//
-//        return !excludePaths.stream()
-//            .anyMatch(excludePath -> excludePath.matches(requestURI, method));
-//    }
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getServletPath();
+        String method = request.getMethod();
+
+        return !excludePaths.stream()
+            .anyMatch(excludePath -> excludePath.matches(requestURI, method));
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/src/main/java/com/favoriteplace/global/security/Filter/LoginFilter.java
+++ b/src/main/java/com/favoriteplace/global/security/Filter/LoginFilter.java
@@ -32,5 +32,4 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         return authenticationManager.authenticate(authRequest);
 
     }
-
 }

--- a/src/main/java/com/favoriteplace/global/security/config/FeignClientConfig.java
+++ b/src/main/java/com/favoriteplace/global/security/config/FeignClientConfig.java
@@ -5,6 +5,7 @@ import com.favoriteplace.global.exception.RestApiException;
 import feign.FeignException;
 import feign.Response;
 import feign.codec.ErrorDecoder;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/favoriteplace/global/security/config/FeignClientConfig.java
+++ b/src/main/java/com/favoriteplace/global/security/config/FeignClientConfig.java
@@ -1,0 +1,37 @@
+package com.favoriteplace.global.security.config;
+
+import com.favoriteplace.global.exception.ErrorCode;
+import com.favoriteplace.global.exception.RestApiException;
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.favoriteplace.global.exception.ErrorCode.TOKEN_NOT_VALID;
+
+@Configuration
+public class FeignClientConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new CustomErrorDecoder();
+    }
+
+    public static class CustomErrorDecoder implements ErrorDecoder {
+
+        @Override
+        public Exception decode(String methodKey, Response response) {
+            if (response.status() == 401) {
+                // Unauthorized (401) 에러 처리
+                return new RestApiException(TOKEN_NOT_VALID);
+            } else if (response.status() == 404) {
+                // Not Found (404) 에러 처리
+                return new RestApiException(ErrorCode.NOT_FOUND);
+            }
+
+            // 기본적으로는 FeignException을 던집니다.
+            return FeignException.errorStatus(methodKey, response);
+        }
+    }
+}

--- a/src/main/java/com/favoriteplace/global/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/favoriteplace/global/security/handler/CustomAuthenticationSuccessHandler.java
@@ -44,7 +44,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
         //인증 정보를 기반으로 JWT 토큰 생성
         response.setContentType(APPLICATION_JSON_VALUE);
-        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+        TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getEmail());
 
         //refreshToken 업데이트
         member.updateRefreshToken(tokenInfo.getRefreshToken());

--- a/src/main/java/com/favoriteplace/global/security/kakao/KakaoClient.java
+++ b/src/main/java/com/favoriteplace/global/security/kakao/KakaoClient.java
@@ -1,0 +1,14 @@
+package com.favoriteplace.global.security.kakao;
+
+import com.favoriteplace.app.dto.member.AuthKakaoLoginDto;
+import com.favoriteplace.global.security.config.FeignClientConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(value = "kakaoClient", url = "https://kapi.kakao.com", configuration = FeignClientConfig.class)
+public interface KakaoClient {
+
+    @GetMapping("/v2/user/me")
+    AuthKakaoLoginDto getUserInfo(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/com/favoriteplace/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/favoriteplace/global/security/provider/JwtTokenProvider.java
@@ -29,8 +29,8 @@ public class JwtTokenProvider {
     private final Long refreshExpirePeriod = 24 * 60 * 60 * 1000L * 40;
     private final UserDetailsService userDetailsService;
 
-    public TokenInfo generateToken(Authentication authentication) {
-        Claims claims = Jwts.claims().setSubject(authentication.getName());
+    public TokenInfo generateToken(String userEmail) {
+        Claims claims = Jwts.claims().setSubject(userEmail);
         Date now = new Date();
 
         // Access Token 생성
@@ -42,7 +42,7 @@ public class JwtTokenProvider {
             .compact();
 
         // Refresh Token 생성
-        String refreshToken = createRefreshToken(authentication);
+        String refreshToken = createRefreshToken(userEmail);
         return TokenInfo.builder()
             .grantType("Bearer")
             .accessToken(accessToken)
@@ -50,8 +50,8 @@ public class JwtTokenProvider {
             .build();
     }
 
-    public String createRefreshToken(Authentication authentication){
-        Claims claims = Jwts.claims().setSubject(authentication.getName());
+    public String createRefreshToken(String userEmail){
+        Claims claims = Jwts.claims().setSubject(userEmail);
         Date now = new Date();
 
         String refreshToken = Jwts.builder()


### PR DESCRIPTION
# 📄 Work Description
- FeignClient를 사용하여 카카오 로그인을 구현했습니다.

# ⚙️ ISSUE
- closed #118 

# 📷 Screenshot
- postman 성공 화면
<img width="1319" alt="스크린샷 2024-08-19 오후 7 30 36" src="https://github.com/user-attachments/assets/66f3da61-5d47-43eb-b249-de0ea86346bd">


# 💬 To Reviewers
1. FeignClient를 사용하여 카카오 로그인을 구현했습니다! kakao api 통신시에, RestTemplate, WebClient 와 같은 방식이 아닌 OpenFeign을 선택한 이유는 아래와 같습니다.
- SpringMvc에서 제공되는 어노테이션을 그대로 사용할 수 있다. (Spring Cloud의 starter-openfeign을 사용할 경우)
- RestTemplate 보다 간편하게 사용할 수 있으며 가독성이 좋다.
```java
//FeignClient
implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.4'
```
<br/>
아래와 같이 인터페이스를 만들고, 내부에 호출할 메서드(kakao 서버와 통신할)를 만들었습니다.

https://github.com/UMC5th-bias/Server/blob/b672e876e9438903ccfb9dca526c2c7a779c7f30/src/main/java/com/favoriteplace/global/security/kakao/KakaoClient.java#L9-L14

<br/>
현재 로직상 토큰 claim을 생성할 때 사용자의 이메일을 기반으로 만들고 있기 때문에, 카카오 로그인시에 필수로 이메일을 받아오도록 했습니다!

https://github.com/UMC5th-bias/Server/blob/b672e876e9438903ccfb9dca526c2c7a779c7f30/src/main/java/com/favoriteplace/app/dto/member/AuthKakaoLoginDto.java#L5-L15

<br/>
사용자에게 보여지는 화면은 다음과 같습니다! <br/>
<img width="350" alt="스크린샷 2024-08-19 오후 7 48 58" src="https://github.com/user-attachments/assets/a6875244-2bee-4f5a-81fe-d8a1290040f1">


# 🔗 Reference
[참고한 블로그](https://seowoolog.tistory.com/66)