### PR TITLE
[FIX #149] 자유게시글, 성지순례 인증글 이미지 업로드 로직 수정

### DIFF
--- a/src/main/java/com/favoriteplace/app/controller/PostController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PostController.java
@@ -125,8 +125,7 @@ public class PostController {
         Member member = securityUtil.getUser();
         postCommandService.modifyPost(postId, data, images, member);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message("게시글이 수정되었습니다.").build(),
-                HttpStatus.OK
+                HttpStatus.NO_CONTENT
         );
     }
 }

--- a/src/main/java/com/favoriteplace/app/domain/community/GuestBook.java
+++ b/src/main/java/com/favoriteplace/app/domain/community/GuestBook.java
@@ -1,22 +1,28 @@
 package com.favoriteplace.app.domain.community;
 
-import com.favoriteplace.app.domain.Image;
-import com.favoriteplace.app.domain.Member;
-import com.favoriteplace.app.domain.common.BaseTimeEntity;
-import com.favoriteplace.app.domain.travel.Pilgrimage;
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
+
+import com.favoriteplace.app.domain.Image;
+import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.domain.common.BaseTimeEntity;
+import com.favoriteplace.app.domain.travel.Pilgrimage;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -85,6 +91,16 @@ public class GuestBook extends BaseTimeEntity {
     public void addComment(Comment comment){
         comment.setGuestBook(this);
         this.comments.add(comment);
+    }
+
+    public void addImages(List<String> imageUrls){
+        for(String imageUrl:imageUrls){
+            Image newImage = Image.builder()
+                    .guestBook(this)
+                    .url(imageUrl)
+                    .build();
+            this.images.add(newImage);
+        }
     }
 
 }

--- a/src/main/java/com/favoriteplace/app/domain/community/Post.java
+++ b/src/main/java/com/favoriteplace/app/domain/community/Post.java
@@ -1,21 +1,27 @@
 package com.favoriteplace.app.domain.community;
 
-import com.favoriteplace.app.domain.Image;
-import com.favoriteplace.app.domain.Member;
-import com.favoriteplace.app.domain.common.BaseTimeEntity;
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
+
+import com.favoriteplace.app.domain.Image;
+import com.favoriteplace.app.domain.Member;
+import com.favoriteplace.app.domain.common.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -72,6 +78,16 @@ public class Post extends BaseTimeEntity {
             image.setPost(null);
         }
         this.images = new ArrayList<>();
+    }
+
+    public void addImages(List<String> imageUrls){
+        for(String imageUrl:imageUrls){
+            Image newImage = Image.builder()
+                    .post(this)
+                    .url(imageUrl)
+                    .build();
+            this.images.add(newImage);
+        }
     }
 
 }

--- a/src/main/java/com/favoriteplace/app/domain/enums/ItemType.java
+++ b/src/main/java/com/favoriteplace/app/domain/enums/ItemType.java
@@ -1,6 +1,5 @@
 package com.favoriteplace.app.domain.enums;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/favoriteplace/app/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/service/MemberService.java
@@ -1,5 +1,10 @@
 package com.favoriteplace.app.service;
 
+import static com.favoriteplace.global.exception.ErrorCode.NOT_SIGNUP_WITH_KAKAO;
+import static com.favoriteplace.global.exception.ErrorCode.TOKEN_NOT_VALID;
+import static com.favoriteplace.global.exception.ErrorCode.USER_ALREADY_EXISTS;
+import static com.favoriteplace.global.exception.ErrorCode.USER_NOT_FOUND;
+
 import com.favoriteplace.app.domain.Member;
 import com.favoriteplace.app.domain.item.Item;
 import com.favoriteplace.app.dto.UserInfoResponseDto;
@@ -12,13 +17,13 @@ import com.favoriteplace.app.dto.member.MemberDto.MemberSignUpReqDto;
 import com.favoriteplace.app.repository.ItemRepository;
 import com.favoriteplace.app.repository.MemberRepository;
 import com.favoriteplace.global.exception.RestApiException;
-import com.favoriteplace.global.gcpImage.UploadImage;
 import com.favoriteplace.global.s3Image.AmazonS3ImageManager;
 import com.favoriteplace.global.security.kakao.KakaoClient;
 import com.favoriteplace.global.security.provider.JwtTokenProvider;
 import com.favoriteplace.global.util.SecurityUtil;
-
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -28,11 +33,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.List;
-
-import static com.favoriteplace.global.exception.ErrorCode.*;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/favoriteplace/app/service/community/PostCommandService.java
+++ b/src/main/java/com/favoriteplace/app/service/community/PostCommandService.java
@@ -1,6 +1,5 @@
 package com.favoriteplace.app.service.community;
 
-import com.favoriteplace.app.domain.Image;
 import com.favoriteplace.app.domain.Member;
 import com.favoriteplace.app.domain.community.Post;
 import com.favoriteplace.app.dto.community.PostRequestDto;
@@ -9,27 +8,26 @@ import com.favoriteplace.app.repository.LikedPostRepository;
 import com.favoriteplace.app.repository.PostRepository;
 import com.favoriteplace.global.exception.ErrorCode;
 import com.favoriteplace.global.exception.RestApiException;
-import com.favoriteplace.global.gcpImage.ConvertUuidToUrl;
-import com.favoriteplace.global.gcpImage.UploadImage;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
+import com.favoriteplace.global.s3Image.AmazonS3ImageManager;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PostCommandService {
-    private final UploadImage uploadImage;
     private final PostRepository postRepository;
     private final LikedPostRepository likedPostRepository;
     private final ImageRepository imageRepository;
+    private final AmazonS3ImageManager amazonS3ImageManager;
 
     /**
      * 자유게시글 작성
@@ -44,45 +42,16 @@ public class PostCommandService {
                 .images(new ArrayList<>())
                 .content(data.getContent()).likeCount(0L).view(0L)
                 .build();
-        if(images != null && !images.isEmpty()){
-            newPost.getImages().addAll(setImageList(newPost, images));
+
+        try{
+            List<String> imageUrls = amazonS3ImageManager.uploadMultiImages(images);
+            newPost.addImages(imageUrls);
+        }catch (IOException e){
+            log.info("[post image] image 없음");
         }
+
         Post post = postRepository.save(newPost);
         return post.getId();
-    }
-
-    /**
-     * 이미지가 여러개일 때, 이미지 처리하는 로직
-     * @param images
-     * @throws IOException
-     */
-    @Transactional
-    public List<Image> setImageList(Post post, List<MultipartFile> images) throws IOException {
-        //이미지 업로드 관련
-        List<CompletableFuture<Image>> futures = new ArrayList<>();
-
-        for(MultipartFile image: images){
-            if(image != null && !image.isEmpty()){
-                /*
-                String uuid = uploadImage.uploadImageToCloud(image);
-                Image newImage = Image.builder().url(ConvertUuidToUrl.convertUuidToUrl(uuid)).post(post).build();
-                imagesForPost.add(newImage);*/
-                CompletableFuture<Image> future = CompletableFuture.supplyAsync(() -> {
-                    try {
-                        String uuid = uploadImage.uploadImageToCloud(image);
-                        return Image.builder().url(ConvertUuidToUrl.convertUuidToUrl(uuid)).post(post).build();
-                    } catch (IOException e) {
-                        throw new RestApiException(ErrorCode.IMAGE_CANNOT_UPLOAD);
-                    }
-                });
-                futures.add(future);
-            }
-        }
-
-        // 모든 작업이 완료될 때까지 기다림
-        return futures.stream()
-                .map(CompletableFuture::join)
-                .collect(Collectors.toList());
     }
 
     /**
@@ -109,13 +78,19 @@ public class PostCommandService {
         checkAuthOfGuestBook(member, post);
         Optional.ofNullable(data.getTitle()).ifPresent(post::setTitle);
         Optional.ofNullable(data.getContent()).ifPresent(post::setContent);
+
         //기존의 이미지 삭제 필요
         post.getImages().clear();
         imageRepository.deleteByPostId(post.getId());
-        if(images != null && !images.isEmpty()){
-            post.getImages().addAll(setImageList(post, images));
+
+        // 새로운 이미지 등록
+        try{
+            List<String> imageUrls = amazonS3ImageManager.uploadMultiImages(images);
+            post.addImages(imageUrls);
+        }catch (IOException e){
+            log.info("[post image] image 없음");
         }
-        postRepository.save(post);
+
     }
 
     /**

--- a/src/main/java/com/favoriteplace/global/s3Image/AmazonS3ImageManager.java
+++ b/src/main/java/com/favoriteplace/global/s3Image/AmazonS3ImageManager.java
@@ -55,6 +55,18 @@ public class AmazonS3ImageManager {
         return futures;
     }
 
+    public List<String> uploadMultiImages(List<MultipartFile> images) throws IOException{
+        List<CompletableFuture<String>> futures = new ArrayList<>();
+        for(MultipartFile file:images){
+            futures.add(upload(file));
+        }
+        List<String> imageUrls = new ArrayList<>();
+        futures.forEach(
+                future -> imageUrls.add(future.join())
+        );
+        return imageUrls;
+    }
+
     private String upload(File uploadFile, String s3FileName) {
         String fileName = s3Config.getFilePath()+ "/" + s3FileName + uploadFile.getName();
         String uploadImageUrl = putS3(uploadFile, fileName);


### PR DESCRIPTION
# 📄 Work Description
- 자유게시글, 성지순례 인증글 이미지 업로드 로직 수정


# ⚙️ ISSUE
- closed #149 


# 📷 Screenshot
<img width="849" alt="스크린샷 2024-09-21 오후 5 19 55" src="https://github.com/user-attachments/assets/387d97a3-1336-4083-9512-3ec97121f57f">


# 💬 To Reviewers
- 성지순례 인글증 등록, 수정 API : 이미지 업로드 수정
- 자유게시글 등록, 수정 API : 이미지 업로드 수정
- 자유게시글 수정 API : response Body 없이 204만 반환하는 것으로 수정했습니다.

# 🔗 Reference

