### PR TITLE
[Refactor #153] 자유게시판, 성지순례 인증글 response DTO, status 수정

### DIFF
--- a/src/main/java/com/favoriteplace/app/controller/GuestBookCommentController.java
+++ b/src/main/java/com/favoriteplace/app/controller/GuestBookCommentController.java
@@ -58,7 +58,7 @@ public class GuestBookCommentController {
     }
 
     @PostMapping("/{guestbook_id}/comments/{comment_id}/notification")
-    public ResponseEntity<?> sendGuestBookNotification(
+    public ResponseEntity<Void> sendGuestBookNotification(
             @PathVariable("guestbook_id") Long guestbookId,
             @PathVariable("comment_id") Long commentId
     ){
@@ -70,7 +70,7 @@ public class GuestBookCommentController {
             @ApiResponse(responseCode = "204")
     })
     @PutMapping("/comments/{comment_id}")
-    public ResponseEntity<?> modifyGuestBookComment(
+    public ResponseEntity<Void> modifyGuestBookComment(
             @PathVariable("comment_id") Long commentId,
             @RequestBody CommentRequestDto.ModifyComment dto
     ){
@@ -85,7 +85,7 @@ public class GuestBookCommentController {
             @ApiResponse(responseCode = "204")
     })
     @DeleteMapping("/comments/{comment_id}")
-    public ResponseEntity<?> deleteGuestBookComment(
+    public ResponseEntity<Void> deleteGuestBookComment(
             @PathVariable("comment_id") Long commentId
     ){
         Member member = securityUtil.getUser();

--- a/src/main/java/com/favoriteplace/app/controller/GuestBookCommentController.java
+++ b/src/main/java/com/favoriteplace/app/controller/GuestBookCommentController.java
@@ -1,20 +1,20 @@
 package com.favoriteplace.app.controller;
 
 import com.favoriteplace.app.domain.Member;
-import com.favoriteplace.app.dto.community.*;
-import com.favoriteplace.app.repository.MemberRepository;
+import com.favoriteplace.app.dto.community.CommentRequestDto;
+import com.favoriteplace.app.dto.community.CommentResponseDto;
+import com.favoriteplace.app.dto.community.GuestBookResponseDto;
+import com.favoriteplace.app.dto.community.PostResponseDto;
 import com.favoriteplace.app.service.community.CommentCommandService;
 import com.favoriteplace.app.service.community.CommentQueryService;
 import com.favoriteplace.global.util.SecurityUtil;
-import com.google.api.Http;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/posts/guestbooks")
@@ -23,7 +23,6 @@ public class GuestBookCommentController {
     private final SecurityUtil securityUtil;
     private final CommentQueryService commentQueryService;
     private final CommentCommandService commentCommandService;
-    private final MemberRepository memberRepository;
 
     @GetMapping("/my-comments")
     public ResponseEntity<GuestBookResponseDto.MyGuestBookCommentDto> getMyComments(
@@ -46,15 +45,14 @@ public class GuestBookCommentController {
     }
 
     @PostMapping("/{guestbook_id}/comments")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> createGuestBookComment(
+    public ResponseEntity<PostResponseDto.CommentSuccessResponseDto> createGuestBookComment(
             @PathVariable("guestbook_id") Long guestbookId,
             @RequestBody CommentRequestDto.CreateComment guestBookCommentDto
     ){
         Member member = securityUtil.getUser();
-//        Member member = memberRepository.findById(1L).orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
         Long commentId = commentCommandService.createGuestBookComment(member, guestbookId, guestBookCommentDto);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().commentId(commentId).message("댓글이 성공적으로 등록했습니다.").build(),
+                PostResponseDto.CommentSuccessResponseDto.builder().commentId(commentId).build(),
                 HttpStatus.OK
         );
     }
@@ -68,30 +66,32 @@ public class GuestBookCommentController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @PutMapping("/comments/{comment_id}")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> modifyGuestBookComment(
+    public ResponseEntity<?> modifyGuestBookComment(
             @PathVariable("comment_id") Long commentId,
             @RequestBody CommentRequestDto.ModifyComment dto
     ){
         Member member = securityUtil.getUser();
-//        Member member = memberRepository.findById(1L).orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
         commentCommandService.modifyComment(member, commentId, dto.getContent());
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message("댓글 성공적으로 수정했습니다.").build(),
-                HttpStatus.OK
+                HttpStatus.NO_CONTENT
         );
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @DeleteMapping("/comments/{comment_id}")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> deleteGuestBookComment(
+    public ResponseEntity<?> deleteGuestBookComment(
             @PathVariable("comment_id") Long commentId
     ){
         Member member = securityUtil.getUser();
-//        Member member = memberRepository.findById(1L).orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
         commentCommandService.deleteComment(member, commentId);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message("댓글 성공적으로 삭제했습니다.").build(),
-                HttpStatus.OK
+                HttpStatus.NO_CONTENT
         );
     }
 

--- a/src/main/java/com/favoriteplace/app/controller/GuestBookController.java
+++ b/src/main/java/com/favoriteplace/app/controller/GuestBookController.java
@@ -86,7 +86,7 @@ public class GuestBookController {
             @ApiResponse(responseCode = "204")
     })
     @PatchMapping("/{guestbook_id}")
-    public ResponseEntity<?> modifyGuestBook(
+    public ResponseEntity<Void> modifyGuestBook(
             @PathVariable("guestbook_id") Long guestbookId,
             @RequestPart GuestBookRequestDto.ModifyGuestBookDto data,
             @RequestPart(required = false) List<MultipartFile> images
@@ -102,7 +102,7 @@ public class GuestBookController {
             @ApiResponse(responseCode = "204")
     })
     @DeleteMapping("/{guestbook_id}")
-    public ResponseEntity<?> deleteGuestBook(
+    public ResponseEntity<Void> deleteGuestBook(
             @PathVariable("guestbook_id") Long guestbookId
     ){
         Member member = securityUtil.getUser();

--- a/src/main/java/com/favoriteplace/app/controller/GuestBookController.java
+++ b/src/main/java/com/favoriteplace/app/controller/GuestBookController.java
@@ -8,6 +8,8 @@ import com.favoriteplace.app.service.community.GuestBookCommandService;
 import com.favoriteplace.app.service.community.GuestBookQueryService;
 import com.favoriteplace.app.service.community.LikedPostService;
 import com.favoriteplace.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -80,8 +82,11 @@ public class GuestBookController {
         return guestBookQueryService.getDetailGuestBookInfo(guestBookId, member);
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @PatchMapping("/{guestbook_id}")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> modifyGuestBook(
+    public ResponseEntity<?> modifyGuestBook(
             @PathVariable("guestbook_id") Long guestbookId,
             @RequestPart GuestBookRequestDto.ModifyGuestBookDto data,
             @RequestPart(required = false) List<MultipartFile> images
@@ -89,38 +94,39 @@ public class GuestBookController {
         Member member = securityUtil.getUser();
         guestBookCommandService.modifyGuestBook(member, guestbookId, data, images);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message("성지순례 인증글을 성공적으로 수정했습니다.").build(),
-                HttpStatus.OK
+                HttpStatus.NO_CONTENT
         );
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @DeleteMapping("/{guestbook_id}")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> deleteGuestBook(
+    public ResponseEntity<?> deleteGuestBook(
             @PathVariable("guestbook_id") Long guestbookId
     ){
         Member member = securityUtil.getUser();
         guestBookCommandService.deleteGuestBook(member, guestbookId);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message("성지순례 인증글을 성공적으로 삭제했습니다.").build(),
-                HttpStatus.OK
+                HttpStatus.NO_CONTENT
         );
     }
 
     @PostMapping("/{guestbook_id}/like")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> modifyGuestBookLike(
+    public ResponseEntity<PostResponseDto.LikeSuccessResponseDto> modifyGuestBookLike(
             @PathVariable("guestbook_id") Long guestbookId
     ){
         Member member = securityUtil.getUser();
-        String message = likedPostService.modifyGuestBookLike(member, guestbookId);
+        Long likedId = likedPostService.modifyGuestBookLike(member, guestbookId);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message(message).build(),
+                PostResponseDto.LikeSuccessResponseDto.builder().likedId(likedId).build(),
                 HttpStatus.OK
         );
     }
 
     // 성지순례 장소 방문 인증글 작성하기
     @PostMapping("/{pilgrimage_id}")
-    public PostResponseDto.SuccessResponseDto postToPilgrimage(
+    public PostResponseDto.GuestBookIdResponseDto postToPilgrimage(
             @PathVariable("pilgrimage_id") Long pilgrimageId,
             @RequestPart GuestBookRequestDto.ModifyGuestBookDto data,
             @RequestPart(required = false) List<MultipartFile> images

--- a/src/main/java/com/favoriteplace/app/controller/MyPageController.java
+++ b/src/main/java/com/favoriteplace/app/controller/MyPageController.java
@@ -8,6 +8,8 @@ import com.favoriteplace.app.dto.community.CommentResponseDto;
 import com.favoriteplace.app.service.MyPageCommandService;
 import com.favoriteplace.app.service.MyPageQueryService;
 import com.favoriteplace.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -89,6 +91,9 @@ public class MyPageController {
     }
 
     //FCM token 등록 & 변경
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @PatchMapping("/fcmToken")
     public ResponseEntity<?> modifyFcmToken(
             @Valid @RequestBody MyFcmTokenDto request

--- a/src/main/java/com/favoriteplace/app/controller/NotificationController.java
+++ b/src/main/java/com/favoriteplace/app/controller/NotificationController.java
@@ -36,7 +36,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "204")
     })
     @PatchMapping()
-    public ResponseEntity<?> readAllNotification(){
+    public ResponseEntity<Void> readAllNotification(){
         Member member = securityUtil.getUser();
         notificationService.readAllNotification(member);
         return ResponseEntity.noContent().build();
@@ -47,7 +47,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "204")
     })
     @PatchMapping("/{notificationId}")
-    public ResponseEntity<?> readNotification(
+    public ResponseEntity<Void> readNotification(
             @PathVariable Long notificationId
     ){
         Member member = securityUtil.getUser();
@@ -60,7 +60,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "204")
     })
     @DeleteMapping("/{notificationId}")
-    public ResponseEntity<?> deleteNotification(
+    public ResponseEntity<Void> deleteNotification(
             @PathVariable Long notificationId
     ){
         Member member = securityUtil.getUser();

--- a/src/main/java/com/favoriteplace/app/controller/NotificationController.java
+++ b/src/main/java/com/favoriteplace/app/controller/NotificationController.java
@@ -4,6 +4,8 @@ import com.favoriteplace.app.domain.Member;
 import com.favoriteplace.app.dto.NotificationResponseDto;
 import com.favoriteplace.app.service.NotificationService;
 import com.favoriteplace.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,9 @@ public class NotificationController {
     }
 
     // 알림 한번에 다 읽음 처리
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @PatchMapping()
     public ResponseEntity<?> readAllNotification(){
         Member member = securityUtil.getUser();
@@ -38,6 +43,9 @@ public class NotificationController {
     }
 
     // 특정 알림 읽음 처리
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @PatchMapping("/{notificationId}")
     public ResponseEntity<?> readNotification(
             @PathVariable Long notificationId
@@ -48,6 +56,9 @@ public class NotificationController {
     }
 
     // 특정 알림 삭제
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @DeleteMapping("/{notificationId}")
     public ResponseEntity<?> deleteNotification(
             @PathVariable Long notificationId

--- a/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PilgrimageApiController.java
@@ -103,7 +103,7 @@ public class PilgrimageApiController {
 
     // 랠리 FCM 구독
     @PostMapping("/{rally_id}/subscribe")
-    public ResponseEntity<?> subscribeRally(@PathVariable("rally_id") Long rallyId){
+    public ResponseEntity<Void> subscribeRally(@PathVariable("rally_id") Long rallyId){
         Member member = securityUtil.getUser();
         pilgrimageCommandService.subscribeRally(rallyId, member);
         return ResponseEntity.ok().build();
@@ -111,7 +111,7 @@ public class PilgrimageApiController {
 
     // 랠리 FCM 구독 취소
     @DeleteMapping("/{rally_id}/unsubscribe")
-    public ResponseEntity<?> unsubscribeRally(@PathVariable("rally_id") Long rallyId){
+    public ResponseEntity<Void> unsubscribeRally(@PathVariable("rally_id") Long rallyId){
         Member member = securityUtil.getUser();
         pilgrimageCommandService.unsubscribeRally(rallyId, member);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/favoriteplace/app/controller/PostCommentController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PostCommentController.java
@@ -60,7 +60,7 @@ public class PostCommentController {
     }
 
     @PostMapping("/{post_id}/comments/{comment_id}/notification")
-    public ResponseEntity<?> sendPostNotification(
+    public ResponseEntity<Void> sendPostNotification(
             @PathVariable("post_id") long postId,
             @PathVariable("comment_id") long commentId
     ){
@@ -72,7 +72,7 @@ public class PostCommentController {
             @ApiResponse(responseCode = "204")
     })
     @PutMapping("/comments/{comment_id}")
-    public ResponseEntity<?> modifyPostComment(
+    public ResponseEntity<Void> modifyPostComment(
             @PathVariable("comment_id") long commentId,
             @RequestBody CommentRequestDto.ModifyComment dto
     ){

--- a/src/main/java/com/favoriteplace/app/controller/PostController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PostController.java
@@ -3,11 +3,12 @@ package com.favoriteplace.app.controller;
 import com.favoriteplace.app.domain.Member;
 import com.favoriteplace.app.dto.community.PostRequestDto;
 import com.favoriteplace.app.dto.community.PostResponseDto;
-import com.favoriteplace.app.service.MemberService;
 import com.favoriteplace.app.service.community.LikedPostService;
 import com.favoriteplace.app.service.community.PostCommandService;
 import com.favoriteplace.app.service.community.PostQueryService;
 import com.favoriteplace.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,7 +23,6 @@ import java.util.List;
 @RequestMapping("/posts/free")
 @RequiredArgsConstructor
 public class PostController {
-    private final MemberService memberService;
     private final PostQueryService postQueryService;
     private final PostCommandService postCommandService;
     private final LikedPostService likedPostService;
@@ -92,32 +92,37 @@ public class PostController {
                 HttpStatus.OK);
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @DeleteMapping("/{post_id}")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> deletePost(
+    public ResponseEntity<?> deletePost(
             @PathVariable("post_id") long postId
     ){
         Member member = securityUtil.getUser();
         postCommandService.deletePost(postId, member);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message("게시글이 성공적으로 삭제되었습니다.").build(),
-                HttpStatus.OK
+                HttpStatus.NO_CONTENT
         );
     }
 
-    @PutMapping("/{post_id}/like")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> modifyPostLike(
+    @PostMapping("/{post_id}/like")
+    public ResponseEntity<PostResponseDto.LikeSuccessResponseDto> modifyPostLike(
             @PathVariable("post_id") long postId
     ){
         Member member = securityUtil.getUser();
-        String message = likedPostService.modifyPostLike(member, postId);
+        Long likedId = likedPostService.modifyPostLike(member, postId);
         return new ResponseEntity<>(
-                PostResponseDto.SuccessResponseDto.builder().message(message).build(),
+                PostResponseDto.LikeSuccessResponseDto.builder().likedId(likedId).build(),
                 HttpStatus.OK
         );
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204")
+    })
     @PatchMapping("/{post_id}")
-    public ResponseEntity<PostResponseDto.SuccessResponseDto> modifyPost(
+    public ResponseEntity<?> modifyPost(
             @PathVariable("post_id") Long postId,
             @RequestPart PostRequestDto data,
             @RequestPart(required = false) List<MultipartFile> images

--- a/src/main/java/com/favoriteplace/app/controller/PostController.java
+++ b/src/main/java/com/favoriteplace/app/controller/PostController.java
@@ -96,7 +96,7 @@ public class PostController {
             @ApiResponse(responseCode = "204")
     })
     @DeleteMapping("/{post_id}")
-    public ResponseEntity<?> deletePost(
+    public ResponseEntity<Void> deletePost(
             @PathVariable("post_id") long postId
     ){
         Member member = securityUtil.getUser();
@@ -122,7 +122,7 @@ public class PostController {
             @ApiResponse(responseCode = "204")
     })
     @PatchMapping("/{post_id}")
-    public ResponseEntity<?> modifyPost(
+    public ResponseEntity<Void> modifyPost(
             @PathVariable("post_id") Long postId,
             @RequestPart PostRequestDto data,
             @RequestPart(required = false) List<MultipartFile> images

--- a/src/main/java/com/favoriteplace/app/domain/community/GuestBook.java
+++ b/src/main/java/com/favoriteplace/app/domain/community/GuestBook.java
@@ -70,6 +70,7 @@ public class GuestBook extends BaseTimeEntity {
     public void setTitle(String title){this.title = title;}
     public void setContent(String content){this.content = content;}
     public void increaseView(){this.view++;}
+    public void decreaseView(){this.view--;}
 
     public void setHashTag(HashTag hashTag){
         hashTag.setGuestBook(this);

--- a/src/main/java/com/favoriteplace/app/dto/community/PostResponseDto.java
+++ b/src/main/java/com/favoriteplace/app/dto/community/PostResponseDto.java
@@ -14,9 +14,16 @@ public class PostResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SuccessResponseDto{
+    public static class CommentSuccessResponseDto {
         private Long commentId;
-        private String message;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LikeSuccessResponseDto{
+        private Long likedId;
     }
 
     @Getter
@@ -25,6 +32,14 @@ public class PostResponseDto {
     @AllArgsConstructor
     public static class PostIdResponseDto{
         private Long postId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GuestBookIdResponseDto{
+        private Long guestBookId;
     }
 
     @Builder

--- a/src/main/java/com/favoriteplace/app/service/community/GuestBookCommandService.java
+++ b/src/main/java/com/favoriteplace/app/service/community/GuestBookCommandService.java
@@ -135,7 +135,7 @@ public class GuestBookCommandService {
      * @throws IOException
      */
     @Transactional
-    public PostResponseDto.SuccessResponseDto postGuestBook(Member member, Long pilgrimageId, GuestBookRequestDto.ModifyGuestBookDto data, List<MultipartFile> images) throws IOException {
+    public PostResponseDto.GuestBookIdResponseDto postGuestBook(Member member, Long pilgrimageId, GuestBookRequestDto.ModifyGuestBookDto data, List<MultipartFile> images) throws IOException {
         Pilgrimage pilgrimage = pilgrimageRepository
                 .findById(pilgrimageId).orElseThrow(()->new RestApiException(ErrorCode.PILGRIMAGE_NOT_FOUND));
 
@@ -170,7 +170,7 @@ public class GuestBookCommandService {
         successPostAndPointProcess(member, pilgrimage);
         log.info("success point update");
 
-        return PostResponseDto.SuccessResponseDto.builder().message("인증글 작성에 성공했습니다.").build();
+        return PostResponseDto.GuestBookIdResponseDto.builder().guestBookId(newGuestBook.getId()).build();
     }
 
     private void checkVisited(Pilgrimage pilgrimage, Member member){


### PR DESCRIPTION
# 📄 Work Description
- 자유게시판, 성지순례 인증글 response DTO, status 수정


# ⚙️ ISSUE
- closed #153 


# 📷 Screenshot
<img width="1013" alt="스크린샷 2024-09-24 오후 4 01 58" src="https://github.com/user-attachments/assets/1fe4fdc1-ed88-495b-8fa3-e4aa55123266">


# 💬 To Reviewers
기존의 코드에서는 성공적인 응답일 경우, 모두 `200` 응답값을 반환했습니다. 
Get / Post는 반환할 리소스가 있지만, Put / Patch / Delete의 경우 반환할 리소스가 없는 경우가 있습니다. 이 경우 `204 NO CONTENT`를 반환하여 클라이언트에게 반환할 리소스가 없음을 명시할 수 있습니다. 
또한 response DTO class를 공유하는 과정에서 쓸모없는 값들이 추가가 되어서, 이를 제거했습니다.

<응답값이 204로 수정되면서, response DTO가 없어진 API>
- PUT posts/guestbooks/comments/{comment_id}
- DELETE posts/guestbooks/comments/{comment_id}
- PUT posts/free/comments/{comment_id}
- DELETE posts/free/comments/{comment_id}
- DELETE posts/guestbooks/{guestbook_id}
- PATCH posts/guestbooks/{guestbook_id}
- DELETE posts/free/{post_id}
- PATCH posts/free/{post_id}

<response DTO가 수정된 API>
- POST /posts/free/{post_id}/like
- POST /posts/guestbooks/{post_id}/like
- POST /posts/guestbooks/{pilgrimage_id}
- POST /posts/free/{post_id}/comments
- POST /posts/guestbooks/{guestbook_id}/comments


노션에 명시한 값들은 휴먼 에러가 있을 가능성이 높아서, 스웨거로 확인하는 것이 신뢰성이 높은 것 같습니다!

# 🔗 Reference
